### PR TITLE
fix: Adds vm_agent_platform_updates_enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -1539,6 +1539,14 @@ object({
 
 Default: `null`
 
+### <a name="input_vm_agent_platform_updates_enabled"></a> [vm\_agent\_platform\_updates\_enabled](#input\_vm\_agent\_platform\_updates\_enabled)
+
+Description: (Optional) Specifies whether VMAgent Platform Updates is enabled. Defaults to false
+
+Type: `bool`
+
+Default: `false`
+
 ### <a name="input_vtpm_enabled"></a> [vtpm\_enabled](#input\_vtpm\_enabled)
 
 Description: (Optional) Specifies whether vTPM should be enabled on the virtual machine. Changing this forces a new resource to be created.

--- a/main.linux_vm.tf
+++ b/main.linux_vm.tf
@@ -39,6 +39,7 @@ resource "azurerm_linux_virtual_machine" "this" {
   user_data                                              = var.user_data
   virtual_machine_scale_set_id                           = var.virtual_machine_scale_set_resource_id
   vtpm_enabled                                           = var.vtpm_enabled
+  vm_agent_platform_updates_enabled                      = var.vm_agent_platform_updates_enabled
   zone                                                   = var.zone
 
   os_disk {

--- a/main.linux_vm.tf
+++ b/main.linux_vm.tf
@@ -38,8 +38,8 @@ resource "azurerm_linux_virtual_machine" "this" {
   tags                                                   = local.tags
   user_data                                              = var.user_data
   virtual_machine_scale_set_id                           = var.virtual_machine_scale_set_resource_id
-  vtpm_enabled                                           = var.vtpm_enabled
   vm_agent_platform_updates_enabled                      = var.vm_agent_platform_updates_enabled
+  vtpm_enabled                                           = var.vtpm_enabled
   zone                                                   = var.zone
 
   os_disk {

--- a/main.windows_vm.tf
+++ b/main.windows_vm.tf
@@ -41,6 +41,7 @@ resource "azurerm_windows_virtual_machine" "this" {
   user_data                                              = var.user_data
   virtual_machine_scale_set_id                           = var.virtual_machine_scale_set_resource_id
   vtpm_enabled                                           = var.vtpm_enabled
+  vm_agent_platform_updates_enabled                      = var.vm_agent_platform_updates_enabled
   zone                                                   = var.zone
 
   os_disk {

--- a/main.windows_vm.tf
+++ b/main.windows_vm.tf
@@ -40,8 +40,8 @@ resource "azurerm_windows_virtual_machine" "this" {
   timezone                                               = var.timezone
   user_data                                              = var.user_data
   virtual_machine_scale_set_id                           = var.virtual_machine_scale_set_resource_id
-  vtpm_enabled                                           = var.vtpm_enabled
   vm_agent_platform_updates_enabled                      = var.vm_agent_platform_updates_enabled
+  vtpm_enabled                                           = var.vtpm_enabled
   zone                                                   = var.zone
 
   os_disk {

--- a/variables.tf
+++ b/variables.tf
@@ -1355,16 +1355,16 @@ vm_additional_capabilities = {
 VM_ADDITIONAL_CAPABILITIES
 }
 
-variable "vtpm_enabled" {
-  type        = bool
-  default     = null
-  description = "(Optional) Specifies whether vTPM should be enabled on the virtual machine. Changing this forces a new resource to be created."
-}
-
 variable "vm_agent_platform_updates_enabled" {
   type        = bool
   default     = false
   description = "(Optional) Specifies whether VMAgent Platform Updates is enabled. Defaults to false"
+}
+
+variable "vtpm_enabled" {
+  type        = bool
+  default     = null
+  description = "(Optional) Specifies whether vTPM should be enabled on the virtual machine. Changing this forces a new resource to be created."
 }
 
 variable "winrm_listeners" {

--- a/variables.tf
+++ b/variables.tf
@@ -1361,6 +1361,12 @@ variable "vtpm_enabled" {
   description = "(Optional) Specifies whether vTPM should be enabled on the virtual machine. Changing this forces a new resource to be created."
 }
 
+variable "vm_agent_platform_updates_enabled" {
+  type        = bool
+  default     = false
+  description = "(Optional) Specifies whether VMAgent Platform Updates is enabled. Defaults to false"
+}
+
 variable "winrm_listeners" {
   type = set(object({
     protocol        = string


### PR DESCRIPTION


## Description

Adds vm_agent_platform_updates_enabled variable and updates the vm resources to consume it. Defaults to false as per the default for the resource.

Fixes #118
Closes #118

As per issue:

This property, introduced in azurerm v3.9.4, is missing from the windows & linux VM parameters.

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #118" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks
