### PR TITLE
fix: resolve Make generate_admin_password_or_ssh_key default to false…

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -747,10 +747,16 @@ GALLERY_APPLICATIONS
 }
 
 variable "generate_admin_password_or_ssh_key" {
-  type        = bool
-  default     = true
+  type    = bool
+  default = false
   description = "Set this value to true if the deployment should create a strong password for the admin user. If `os_type` is Linux, this will generate and store an SSH key as the default. However, setting `disable_password_authentication` to `false` will generate and store a password value instead of an ssh key."
+
+  validation {
+    condition = !(var.generate_admin_password_or_ssh_key == true && var.admin_password != null)
+    error_message = "If 'admin_password' is provided, 'generate_admin_password_or_ssh_key' must be set to false."
+  }
 }
+
 
 variable "generated_secrets_key_vault_secret_config" {
   type = object({


### PR DESCRIPTION
… or disable when password/key provided (#152)

## Description

Fixed an issue where user-provided values for `admin_password` was being ignored due to the default value of `generate_admin_password_or_ssh_key` being set to `true`. 

Updated the logic to:
- Disable automatic password or SSH key generation if a value is explicitly provided by the user.

This fix ensures a more intuitive and predictable experience, especially in scenarios where users expect their supplied credentials to be honored.

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #152
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #152" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
