### PR TITLE
Fixing secret creation logic error for deprecated defaults

### DIFF
--- a/locals.auth.tf
+++ b/locals.auth.tf
@@ -68,7 +68,7 @@ locals {
   generate_admin_ssh_key_count = (
     (lower(var.os_type) == "linux") &&
     (
-      (var.generate_admin_password_or_ssh_key == true) ||
+      (var.generate_admin_password_or_ssh_key == true) &&
       (var.account_credentials.admin_credentials.generate_admin_password_or_ssh_key == true)
     ) && (local.password_authentication_disabled == true) ? 1 : 0
   )
@@ -76,13 +76,13 @@ locals {
     (
       (lower(var.os_type) == "windows") &&
       (
-        (var.generate_admin_password_or_ssh_key == true) ||
+        (var.generate_admin_password_or_ssh_key == true) &&
         (var.account_credentials.admin_credentials.generate_admin_password_or_ssh_key == true)
       )
       ) ? 1 : (
       (lower(var.os_type) == "linux") &&
       (
-        (var.generate_admin_password_or_ssh_key == true || var.account_credentials.admin_credentials.generate_admin_password_or_ssh_key == true) && (local.password_authentication_disabled == false)
+        (var.generate_admin_password_or_ssh_key == true && var.account_credentials.admin_credentials.generate_admin_password_or_ssh_key == true) && (local.password_authentication_disabled == false)
       )
     ) ? 1 : 0
   )


### PR DESCRIPTION
## Description

Bug Fix PR to fix secret creation logic error bug.

closes #174  

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
