### PR TITLE
fix: add ignore_casing to backup intent azapi_resource (#228)

### DIFF
--- a/main.backup.tf
+++ b/main.backup.tf
@@ -59,6 +59,7 @@ resource "azapi_resource" "this_backup_intent" {
   read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   response_export_values = ["*"]
   update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_casing          = true
 }
 
 

--- a/main.backup.tf
+++ b/main.backup.tf
@@ -56,10 +56,10 @@ resource "azapi_resource" "this_backup_intent" {
   }
   create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_casing          = true
   read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   response_export_values = ["*"]
   update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
-  ignore_casing          = true
 }
 
 


### PR DESCRIPTION
## Description

Add `ignore_casing = true` to the backup intent `azapi_resource`, fixing Azure API returning inconsistent casing on backup intent response headers which causes configuration drift on every plan.

Original contribution by @paul-e-martin in #229.

Fixes #228
Closes #228

## Type of Change

- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #228" in the PR description.

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all pre-commit checks