### PR TITLE
fix(vm): relax random provider constraint for cross-module compatibility

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -16,7 +16,7 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.6.2, < 5.0.0"
+      version = ">= 3.6.2, < 4.0.0"
     }
     tls = {
       source  = "hashicorp/tls"

--- a/terraform.tf
+++ b/terraform.tf
@@ -16,7 +16,7 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.7"
+      version = ">= 3.6.2, < 5.0.0"
     }
     tls = {
       source  = "hashicorp/tls"


### PR DESCRIPTION
This patch fixes a provider resolution deadlock in mixed AVM deployments.  
Previously, the VM module required random ~> 3.7, while other modules in the same composition required ~> 3.6.2 and ~> 3.6.  
Those constraints have no shared version window, so terraform init fails with Failed to query available provider packages for hashicorp/random.  
By changing VM to random >= 3.6.2, < 5.0.0, we preserve compatibility guarantees and allow Terraform to select a version that satisfies all participating modules.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes [244](https://github.com/Azure/terraform-azurerm-avm-res-compute-virtualmachine/issues/244)" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
