### PR TITLE
fix: add vm_agent_platform_updates_enabled to Linux VM ignore_changes (parity with Windows)

### DIFF
--- a/main.linux_vm.tf
+++ b/main.linux_vm.tf
@@ -159,6 +159,10 @@ resource "azurerm_linux_virtual_machine" "this" {
   ]
 
   lifecycle {
+    ignore_changes = [
+      vm_agent_platform_updates_enabled # Added property to ignore_changes as it continues to detect change in state.
+    ]
+
     precondition {
       condition     = var.os_managed_disk_id == null || var.os_disk.diff_disk_settings == null
       error_message = "The os_managed_disk_id and os_disk.diff_disk_settings are mutually exclusive. Ephemeral OS disks cannot be used when attaching an existing managed disk."


### PR DESCRIPTION
## Description

`azurerm_linux_virtual_machine.this` in `main.linux_vm.tf` does **not** include `vm_agent_platform_updates_enabled` in its `lifecycle.ignore_changes`, whereas `azurerm_windows_virtual_machine.this` in `main.windows_vm.tf` does.

On **azurerm 4.x** the attribute is still `Optional + Computed` in the provider schema. Azure automatically enables platform VM-agent updates and reports `true`, while the module leaves the attribute unset. This produces a **perpetual, non-converging** plan/apply diff on every run for Linux VMs:

```
~ resource "azurerm_linux_virtual_machine" "this" {
    ~ vm_agent_platform_updates_enabled = true -> false
}
```

Unlike a warning, this is an actual in-place change on every apply that never converges. Windows VMs are unaffected because they already carry the `ignore_changes` entry.

## Change

Add `vm_agent_platform_updates_enabled` to the Linux VM `lifecycle.ignore_changes` block, mirroring the existing Windows VM handling (same comment used for consistency).

## Related

Relates to #189. Reproduced with module v0.21.0 and azurerm 4.74.0.