### PR TITLE
fix: validate Windows computer_name length and correct name error mes…

### DIFF
--- a/main.windows_vm.tf
+++ b/main.windows_vm.tf
@@ -182,6 +182,10 @@ resource "azurerm_windows_virtual_machine" "this" {
       condition     = var.os_managed_disk_id == null || var.os_disk.diff_disk_settings == null
       error_message = "The os_managed_disk_id and os_disk.diff_disk_settings are mutually exclusive. Ephemeral OS disks cannot be used when attaching an existing managed disk."
     }
+    precondition {
+      condition     = local.os_disk_is_imported || length(coalesce(var.computer_name, var.name)) <= 15
+      error_message = "For a Windows VM the OS computer name (hostname) must be 15 characters or fewer. It is taken from `computer_name` when set, otherwise it falls back to `name`. The effective computer name here exceeds 15 characters - set `computer_name` to a value of 15 characters or fewer. (The `name` / ARM resource name itself may be up to 64 characters.)"
+    }
   }
   depends_on = [ #set explicit depends on for each association to address delete order issues.
     azurerm_network_interface.virtualmachine_network_interfaces,

--- a/variables.tf
+++ b/variables.tf
@@ -19,7 +19,7 @@ variable "name" {
 
   validation {
     condition     = can(regex("^.{1,64}$", var.name))
-    error_message = "virtual machine names for linux must be between 1 and 64 characters in length. Virtual machine name for windows must be between 1 and 20 characters in length."
+    error_message = "The virtual machine name (the ARM resource name) must be between 1 and 64 characters in length. Note: for Windows the OS computer name (hostname) is limited to 15 characters, so if `name` exceeds 15 characters you must also set `computer_name` to a value of 15 characters or fewer."
   }
 }
 


### PR DESCRIPTION
## Description

Windows OS computer names (hostnames) are capped at 15 characters, and the module defaults computer_name to `name` via coalesce(). When `name` exceeds 15 characters and computer_name is unset, the azurerm provider fails with a confusing error about the coalesced value. Add a precondition on the Windows VM resource that fails early with clear guidance to set computer_name.

Also fix the inaccurate `name` validation error message: Windows VM resource names may be up to 64 characters (the 15-char limit applies to the OS computer name, not the ARM resource name).

Closes #351

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
