### PR TITLE
fix: replace deprecated enable_automatic_updates with automatic_updates_enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.4)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116, < 5.0)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 4.42, < 5.0)
 
 - <a name="requirement_modtm"></a> [modtm](#requirement\_modtm) (~> 0.3)
 
@@ -262,6 +262,14 @@ Description: (Optional) Should Extension Operations be allowed on this Virtual M
 Type: `bool`
 
 Default: `true`
+
+### <a name="input_automatic_updates_enabled"></a> [automatic\_updates\_enabled](#input\_automatic\_updates\_enabled)
+
+Description: (Optional) Specifies if Automatic Updates are Enabled for the Windows Virtual Machine. Changing this forces a new resource to be created. Defaults to `true` when neither this input nor the deprecated `enable_automatic_updates` input is set.
+
+Type: `bool`
+
+Default: `null`
 
 ### <a name="input_availability_set_resource_id"></a> [availability\_set\_resource\_id](#input\_availability\_set\_resource\_id)
 
@@ -605,7 +613,7 @@ Default: `null`
 
 ### <a name="input_enable_automatic_updates"></a> [enable\_automatic\_updates](#input\_enable\_automatic\_updates)
 
-Description: (Optional) Specifies if Automatic Updates are Enabled for the Windows Virtual Machine. Changing this forces a new resource to be created. Defaults to `true`.
+Description: DEPRECATED: This input has been renamed to `automatic_updates_enabled` to align with the `azurerm` provider, which removed `enable_automatic_updates` in provider version 5.0. This input will be removed with the release of version v1.0.0. Specifies if Automatic Updates are Enabled for the Windows Virtual Machine. Changing this forces a new resource to be created. Defaults to `true`. If `automatic_updates_enabled` is also set, `automatic_updates_enabled` takes precedence.
 
 Type: `bool`
 

--- a/deprecated_variables.tf
+++ b/deprecated_variables.tf
@@ -58,6 +58,12 @@ variable "disable_password_authentication" {
   nullable    = false
 }
 
+variable "enable_automatic_updates" {
+  type        = bool
+  default     = true
+  description = "DEPRECATED: This input has been renamed to `automatic_updates_enabled` to align with the `azurerm` provider, which removed `enable_automatic_updates` in provider version 5.0. This input will be removed with the release of version v1.0.0. Specifies if Automatic Updates are Enabled for the Windows Virtual Machine. Changing this forces a new resource to be created. Defaults to `true`. If `automatic_updates_enabled` is also set, `automatic_updates_enabled` takes precedence."
+}
+
 variable "generate_admin_password_or_ssh_key" {
   type        = bool
   default     = true

--- a/examples/linux_custom_data_gzip/README.md
+++ b/examples/linux_custom_data_gzip/README.md
@@ -15,7 +15,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116, < 5.0"
+      version = ">= 4.42, < 5.0"
     }
     cloudinit = {
       source  = "hashicorp/cloudinit"
@@ -280,7 +280,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.0)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116, < 5.0)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 4.42, < 5.0)
 
 - <a name="requirement_cloudinit"></a> [cloudinit](#requirement\_cloudinit) (~> 2.0)
 

--- a/examples/linux_custom_data_gzip/main.tf
+++ b/examples/linux_custom_data_gzip/main.tf
@@ -8,7 +8,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116, < 5.0"
+      version = ">= 4.42, < 5.0"
     }
     cloudinit = {
       source  = "hashicorp/cloudinit"

--- a/examples/linux_default/README.md
+++ b/examples/linux_default/README.md
@@ -27,7 +27,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116, < 5.0"
+      version = ">= 4.42, < 5.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -243,7 +243,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.0)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116, < 5.0)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 4.42, < 5.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.7)
 

--- a/examples/linux_default/main.tf
+++ b/examples/linux_default/main.tf
@@ -8,7 +8,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116, < 5.0"
+      version = ">= 4.42, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/linux_os_managed_disk/README.md
+++ b/examples/linux_os_managed_disk/README.md
@@ -29,7 +29,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116, < 5.0"
+      version = ">= 4.42, < 5.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -196,7 +196,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.0)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116, < 5.0)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 4.42, < 5.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.7)
 

--- a/examples/linux_os_managed_disk/main.tf
+++ b/examples/linux_os_managed_disk/main.tf
@@ -8,7 +8,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116, < 5.0"
+      version = ">= 4.42, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/linux_ubuntu_w_ssh_auth/README.md
+++ b/examples/linux_ubuntu_w_ssh_auth/README.md
@@ -31,7 +31,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116, < 5.0"
+      version = ">= 4.42, < 5.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -398,7 +398,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.0)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116, < 5.0)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 4.42, < 5.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.7)
 

--- a/examples/linux_ubuntu_w_ssh_auth/main.tf
+++ b/examples/linux_ubuntu_w_ssh_auth/main.tf
@@ -8,7 +8,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116, < 5.0"
+      version = ">= 4.42, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/linux_ubuntu_with_autogen_password/README.md
+++ b/examples/linux_ubuntu_with_autogen_password/README.md
@@ -29,7 +29,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116, < 5.0"
+      version = ">= 4.42, < 5.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -273,7 +273,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.0)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116, < 5.0)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 4.42, < 5.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.7)
 

--- a/examples/linux_ubuntu_with_autogen_password/main.tf
+++ b/examples/linux_ubuntu_with_autogen_password/main.tf
@@ -8,7 +8,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116, < 5.0"
+      version = ">= 4.42, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/linux_ubuntu_with_plaintext_password/README.md
+++ b/examples/linux_ubuntu_with_plaintext_password/README.md
@@ -29,7 +29,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116, < 5.0"
+      version = ">= 4.42, < 5.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -278,7 +278,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.0)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116, < 5.0)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 4.42, < 5.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.7)
 

--- a/examples/linux_ubuntu_with_plaintext_password/main.tf
+++ b/examples/linux_ubuntu_with_plaintext_password/main.tf
@@ -8,7 +8,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116, < 5.0"
+      version = ">= 4.42, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/linux_vmss_flex_vm_attach/README.md
+++ b/examples/linux_vmss_flex_vm_attach/README.md
@@ -29,7 +29,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116, < 5.0"
+      version = ">= 4.42, < 5.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -330,7 +330,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.0)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116, < 5.0)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 4.42, < 5.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.7)
 

--- a/examples/linux_vmss_flex_vm_attach/main.tf
+++ b/examples/linux_vmss_flex_vm_attach/main.tf
@@ -8,7 +8,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116, < 5.0"
+      version = ">= 4.42, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/linux_zonal_vm_with_zrs_disk/README.md
+++ b/examples/linux_zonal_vm_with_zrs_disk/README.md
@@ -29,7 +29,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116, < 5.0"
+      version = ">= 4.42, < 5.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -254,7 +254,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.0)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116, < 5.0)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 4.42, < 5.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.7)
 

--- a/examples/linux_zonal_vm_with_zrs_disk/main.tf
+++ b/examples/linux_zonal_vm_with_zrs_disk/main.tf
@@ -8,7 +8,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116, < 5.0"
+      version = ">= 4.42, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/windows_minimal/README.md
+++ b/examples/windows_minimal/README.md
@@ -15,7 +15,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116, < 5.0"
+      version = ">= 4.42, < 5.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -189,7 +189,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.0)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116, < 5.0)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 4.42, < 5.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.7)
 

--- a/examples/windows_minimal/main.tf
+++ b/examples/windows_minimal/main.tf
@@ -8,7 +8,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116, < 5.0"
+      version = ">= 4.42, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/windows_w_additional_disks_public_ip/README.md
+++ b/examples/windows_w_additional_disks_public_ip/README.md
@@ -28,7 +28,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116, < 5.0"
+      version = ">= 4.42, < 5.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -294,7 +294,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.0)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116, < 5.0)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 4.42, < 5.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.7)
 

--- a/examples/windows_w_additional_disks_public_ip/main.tf
+++ b/examples/windows_w_additional_disks_public_ip/main.tf
@@ -8,7 +8,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116, < 5.0"
+      version = ">= 4.42, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/windows_w_azure_monitor_agent/README.md
+++ b/examples/windows_w_azure_monitor_agent/README.md
@@ -30,7 +30,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116, < 5.0"
+      version = ">= 4.42, < 5.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -463,7 +463,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.0)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116, < 5.0)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 4.42, < 5.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.7)
 

--- a/examples/windows_w_azure_monitor_agent/main.tf
+++ b/examples/windows_w_azure_monitor_agent/main.tf
@@ -8,7 +8,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116, < 5.0"
+      version = ">= 4.42, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/windows_w_backup/README.md
+++ b/examples/windows_w_backup/README.md
@@ -30,7 +30,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116, < 5.0"
+      version = ">= 4.42, < 5.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -330,7 +330,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.0)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116, < 5.0)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 4.42, < 5.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.7)
 

--- a/examples/windows_w_backup/main.tf
+++ b/examples/windows_w_backup/main.tf
@@ -8,7 +8,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116, < 5.0"
+      version = ">= 4.42, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/windows_w_encryption_at_host/README.md
+++ b/examples/windows_w_encryption_at_host/README.md
@@ -31,7 +31,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116, < 5.0"
+      version = ">= 4.42, < 5.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -329,7 +329,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.0)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116, < 5.0)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 4.42, < 5.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.7)
 

--- a/examples/windows_w_encryption_at_host/main.tf
+++ b/examples/windows_w_encryption_at_host/main.tf
@@ -8,7 +8,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116, < 5.0"
+      version = ">= 4.42, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/windows_w_gallery_application/README.md
+++ b/examples/windows_w_gallery_application/README.md
@@ -34,7 +34,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116, < 5.0"
+      version = ">= 4.42, < 5.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -375,7 +375,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.0)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116, < 5.0)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 4.42, < 5.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.7)
 

--- a/examples/windows_w_gallery_application/main.tf
+++ b/examples/windows_w_gallery_application/main.tf
@@ -8,7 +8,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116, < 5.0"
+      version = ">= 4.42, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/windows_w_load_balancing/README.md
+++ b/examples/windows_w_load_balancing/README.md
@@ -31,7 +31,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116, < 5.0"
+      version = ">= 4.42, < 5.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -439,7 +439,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.0)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116, < 5.0)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 4.42, < 5.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.7)
 

--- a/examples/windows_w_load_balancing/main.tf
+++ b/examples/windows_w_load_balancing/main.tf
@@ -8,7 +8,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116, < 5.0"
+      version = ">= 4.42, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/windows_w_managed_identities_and_rbac/README.md
+++ b/examples/windows_w_managed_identities_and_rbac/README.md
@@ -31,7 +31,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116, < 5.0"
+      version = ">= 4.42, < 5.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -284,7 +284,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.0)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116, < 5.0)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 4.42, < 5.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.7)
 

--- a/examples/windows_w_managed_identities_and_rbac/main.tf
+++ b/examples/windows_w_managed_identities_and_rbac/main.tf
@@ -8,7 +8,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116, < 5.0"
+      version = ">= 4.42, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/windows_w_remote_access/README.md
+++ b/examples/windows_w_remote_access/README.md
@@ -33,7 +33,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116, < 5.0"
+      version = ">= 4.42, < 5.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -546,7 +546,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.0)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116, < 5.0)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 4.42, < 5.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.7)
 

--- a/examples/windows_w_remote_access/main.tf
+++ b/examples/windows_w_remote_access/main.tf
@@ -8,7 +8,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116, < 5.0"
+      version = ">= 4.42, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/windows_w_run_command/README.md
+++ b/examples/windows_w_run_command/README.md
@@ -28,7 +28,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116, < 5.0"
+      version = ">= 4.42, < 5.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -380,7 +380,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.0)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116, < 5.0)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 4.42, < 5.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.7)
 

--- a/examples/windows_w_run_command/main.tf
+++ b/examples/windows_w_run_command/main.tf
@@ -8,7 +8,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116, < 5.0"
+      version = ">= 4.42, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/windows_waf/README.md
+++ b/examples/windows_waf/README.md
@@ -40,7 +40,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116, < 5.0"
+      version = ">= 4.42, < 5.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -560,7 +560,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) (~> 2.15)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116, < 5.0)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 4.42, < 5.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.7)
 

--- a/examples/windows_waf/main.tf
+++ b/examples/windows_waf/main.tf
@@ -12,7 +12,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116, < 5.0"
+      version = ">= 4.42, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,8 @@
 locals {
+  #if automatic updates are set in multiple places, prefer the var.automatic_updates_enabled value.
+  #both inputs default to null/true respectively, so an unset configuration resolves to `true`.
+  #after deprecation, set automatic_updates_enabled to var.automatic_updates_enabled
+  automatic_updates_enabled = var.automatic_updates_enabled != null ? var.automatic_updates_enabled : var.enable_automatic_updates
   #flatten the role assignments for the disks
   disks_role_assignments = { for ra in flatten([
     for dk, dv in var.data_disk_managed_disks : [

--- a/main.windows_vm.tf
+++ b/main.windows_vm.tf
@@ -12,6 +12,7 @@ resource "azurerm_windows_virtual_machine" "this" {
   admin_username = local.admin_username
   #optional properties
   allow_extension_operations                             = var.allow_extension_operations
+  automatic_updates_enabled                              = local.os_disk_is_imported ? null : local.automatic_updates_enabled
   availability_set_id                                    = var.availability_set_resource_id
   bypass_platform_safety_checks_on_user_schedule_enabled = local.os_disk_is_imported ? null : var.bypass_platform_safety_checks_on_user_schedule_enabled
   capacity_reservation_group_id                          = var.capacity_reservation_group_resource_id
@@ -21,7 +22,6 @@ resource "azurerm_windows_virtual_machine" "this" {
   dedicated_host_id                                      = var.dedicated_host_resource_id
   disk_controller_type                                   = var.disk_controller_type
   edge_zone                                              = var.edge_zone
-  enable_automatic_updates                               = local.os_disk_is_imported ? null : var.enable_automatic_updates
   encryption_at_host_enabled                             = var.encryption_at_host_enabled
   eviction_policy                                        = var.eviction_policy
   extensions_time_budget                                 = var.extensions_time_budget

--- a/terraform.tf
+++ b/terraform.tf
@@ -8,7 +8,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.116, < 5.0"
+      version = ">= 4.42, < 5.0"
     }
     modtm = {
       source  = "Azure/modtm"

--- a/variables.tf
+++ b/variables.tf
@@ -204,6 +204,12 @@ variable "allow_extension_operations" {
   description = "(Optional) Should Extension Operations be allowed on this Virtual Machine? Defaults to `true`."
 }
 
+variable "automatic_updates_enabled" {
+  type        = bool
+  default     = null
+  description = "(Optional) Specifies if Automatic Updates are Enabled for the Windows Virtual Machine. Changing this forces a new resource to be created. Defaults to `true` when neither this input nor the deprecated `enable_automatic_updates` input is set."
+}
+
 variable "availability_set_resource_id" {
   type        = string
   default     = null
@@ -512,12 +518,6 @@ variable "edge_zone" {
   type        = string
   default     = null
   description = "(Optional) Specifies the Edge Zone within the Azure Region where this Virtual Machine should exist. Changing this forces a new Virtual Machine to be created."
-}
-
-variable "enable_automatic_updates" {
-  type        = bool
-  default     = true
-  description = "(Optional) Specifies if Automatic Updates are Enabled for the Windows Virtual Machine. Changing this forces a new resource to be created. Defaults to `true`."
 }
 
 variable "enable_telemetry" {


### PR DESCRIPTION
## Description

The `azurerm` provider deprecated `enable_automatic_updates` on `azurerm_windows_virtual_machine` in favour of `automatic_updates_enabled` (added in provider `v4.42.0`, removed entirely in `v5.0`), causing an `Argument is deprecated` warning on every plan/apply.

- `main.windows_vm.tf` now sets `automatic_updates_enabled`, which clears the warning.
- Added an `automatic_updates_enabled` module input (`default = null`).
- Moved `enable_automatic_updates` to `deprecated_variables.tf` for removal in `v1.0.0`. It keeps its `default = true`, and the new input takes precedence when set, so existing configurations continue to work unchanged.
- Raised the `azurerm` version floor to `>= 4.42` in the root module and examples, since `automatic_updates_enabled` does not exist in earlier provider versions.

Both attributes are `Optional+Computed` and `azurerm` 4.x writes the API value into both during refresh, so upgrading produces no diff and no VM replacement despite the attribute being `ForceNew`.

Closes #210

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks
