### PR TITLE
feat: add resource lock support for the OS disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The following resources are used by this module:
 - [azurerm_management_lock.this_disk](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_lock) (resource)
 - [azurerm_management_lock.this_linux_virtualmachine](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_lock) (resource)
 - [azurerm_management_lock.this_nic](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_lock) (resource)
+- [azurerm_management_lock.this_os_disk](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_lock) (resource)
 - [azurerm_management_lock.this_public_ip](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_lock) (resource)
 - [azurerm_management_lock.this_windows_virtualmachine](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_lock) (resource)
 - [azurerm_monitor_diagnostic_setting.this_nic_diags](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) (resource)
@@ -1122,6 +1123,8 @@ Description: Required configuration values for the OS disk on the virtual machin
 - `disk_access_resource_id`          = (Optional) - The Azure Resource ID of the Disk Access resource to use for private endpoint connectivity to this OS Disk. Only supported when `network_access_policy` is set to `AllowPrivate`. Applied to the OS Disk after the virtual machine has been created.
 - `disk_encryption_set_id`           = (Optional) - The Azure Resource ID of the Disk Encryption Set which should be used to Encrypt this OS Disk. Conflicts with secure\_vm\_disk\_encryption\_set\_id. The Disk Encryption Set must have the Reader Role Assignment scoped on the Key Vault - in addition to an Access Policy to the Key Vault
 - `disk_size_gb`                     = (Optional) - The Size of the Internal OS Disk in GB, if you wish to vary from the size used in the image this Virtual Machine is sourced from.
+- `lock_level`                       = (Optional) - Set this value to apply a resource lock to the OS Disk. Possible values are `CanNotDelete` and `ReadOnly`. Unlike the resource level `lock` variable, this value is not inherited and must be set explicitly. Note that a `CanNotDelete` lock on the OS Disk will block deletion of the virtual machine, and a `ReadOnly` lock will additionally block operations such as resizing the disk, until the lock is removed.
+- `lock_name`                        = (Optional) - The name for the lock on the OS Disk. If not specified, a name is generated from the virtual machine name.
 - `name`                             = (Optional) - The name which should be used for the Internal OS Disk. Changing this forces a new resource to be created.
 - `network_access_policy`            = (Optional) - Policy for accessing the OS Disk via network. Possible values are `AllowAll`, `AllowPrivate`, and `DenyAll`. Leave unset to keep the Azure default (`AllowAll`). Applied to the OS Disk after the virtual machine has been created.
 - `public_network_access_enabled`    = (Optional) - Should it be allowed to access the OS Disk via the public network? Leave unset to keep the Azure default (`true`). Set to `false` to disable public network access on the OS Disk. Applied to the OS Disk after the virtual machine has been created.
@@ -1168,6 +1171,13 @@ os_disk = {
   network_access_policy         = "AllowPrivate"
   disk_access_resource_id       = azurerm_disk_access.this.id
 }
+
+#protect the os disk from deletion with a resource lock
+os_disk = {
+  caching              = "ReadWrite"
+  storage_account_type = "Premium_LRS"
+  lock_level           = "CanNotDelete"
+}
 ```
 
 Type:
@@ -1179,6 +1189,8 @@ object({
     disk_access_resource_id          = optional(string)
     disk_encryption_set_id           = optional(string)
     disk_size_gb                     = optional(number)
+    lock_level                       = optional(string, null)
+    lock_name                        = optional(string, null)
     name                             = optional(string)
     network_access_policy            = optional(string)
     public_network_access_enabled    = optional(bool)

--- a/locals.tf
+++ b/locals.tf
@@ -126,6 +126,9 @@ locals {
   # because os_managed_disk_id is typically a computed resource attribute (unknown at plan time),
   # which would make count expressions that depend on this local undeterminable during planning.
   os_disk_is_imported = var.os_disk_attach_mode
+  #the OS disk is an inline block on the vm resource rather than a separate managed disk, so its resource id is read
+  #back off the created virtual machine.
+  os_disk_resource_id = (lower(var.os_type) == "windows") ? azurerm_windows_virtual_machine.this[0].os_disk[0].id : azurerm_linux_virtual_machine.this[0].os_disk[0].id
   #concat the input variable with the simple list going forward - this is a placeholder so that we can continue to reference the local source image reference value when it includes the simpleOS option.
   source_image_reference = var.source_image_reference
   #get the first system managed identity id if it is provisioned and depending on whether the vm type is linux or windows

--- a/main.disks.tf
+++ b/main.disks.tf
@@ -119,6 +119,26 @@ resource "azurerm_management_lock" "this_disk" {
   ]
 }
 
+#configure a resource lock on the OS Disk if the lock values are set. The OS Disk is an inline block on the virtual
+#machine resource, so the lock is scoped to the disk id read back off the created virtual machine. The dependencies
+#ensure the disk is fully provisioned before a lock is applied, since a ReadOnly lock blocks subsequent writes.
+resource "azurerm_management_lock" "this_os_disk" {
+  count = var.os_disk.lock_level != null ? 1 : 0
+
+  lock_level = var.os_disk.lock_level
+  name       = coalesce(var.os_disk.lock_name, "${var.name}-os-disk-lock")
+  scope      = local.os_disk_resource_id
+  notes      = var.os_disk.lock_level == "CanNotDelete" ? "Cannot delete the resource or its child resources." : "Cannot delete or modify the resource or its child resources."
+
+  depends_on = [
+    azurerm_virtual_machine_data_disk_attachment.this_linux,
+    azurerm_virtual_machine_data_disk_attachment.this_windows,
+    azurerm_windows_virtual_machine.this,
+    azurerm_linux_virtual_machine.this,
+    module.extension
+  ]
+}
+
 #assign permissions to the virtual machine if enabled and role assignments included
 resource "azurerm_role_assignment" "disks" {
   for_each = local.disks_role_assignments

--- a/main.os_disk.tf
+++ b/main.os_disk.tf
@@ -20,7 +20,6 @@ locals {
     var.os_disk.network_access_policy != null,
     var.os_disk.disk_access_resource_id != null
   ])
-  os_disk_resource_id = (lower(var.os_type) == "windows") ? azurerm_windows_virtual_machine.this[0].os_disk[0].id : azurerm_linux_virtual_machine.this[0].os_disk[0].id
 }
 
 resource "azapi_update_resource" "this_os_disk_network_access" {

--- a/tests/unit/os_disk_lock.tftest.hcl
+++ b/tests/unit/os_disk_lock.tftest.hcl
@@ -1,0 +1,156 @@
+mock_provider "azapi" {}
+mock_provider "azurerm" {
+  mock_resource "azurerm_network_interface" {
+    defaults = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/networkInterfaces/nic-test"
+    }
+  }
+
+  mock_resource "azurerm_linux_virtual_machine" {
+    defaults = {
+      os_disk = {
+        id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/disks/vm-os-disk-lock-osdisk"
+      }
+    }
+  }
+}
+mock_provider "modtm" {}
+mock_provider "random" {}
+mock_provider "tls" {}
+
+variables {
+  location            = "eastus"
+  name                = "vm-os-disk-lock"
+  resource_group_name = "rg-test"
+  zone                = "1"
+  os_type             = "Linux"
+  #a throwaway public key so the mocked tls provider doesn't have to produce a valid one.
+  account_credentials = {
+    admin_credentials = {
+      generate_admin_password_or_ssh_key = false
+      ssh_keys                           = ["ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQChdqi+GemIsVzHEtcwAuBai8F9qfDB0vvCukphTa4WGZFJ4BJCTGhzNU3FZmBlP8/uuF8MVKXwDFsM8dSZnWldbGTBK/US6qBHK4ewu/8Fd4AqT00yPeb4354wcvyluAKqLeXh29/ILTSO/WlW4tGD/Mzx9B/qicYHyEqrYY307yAiTHps3Yi02OzG1BAprhdDz3OCyzvjgHeM8ltKokrv1/+h49oTX96pIsSVNaH6RBIsSiTSD4DAnlpeqrSacwP6az1IDFfkDob6hn2I29lJitQWuIw/Vi2hiUysPqPhs8StpXfasVfjK8NwQA0eu3KBRAGSM6OnXk+NVxeise45rjRVBKtSLd37KRQWZrOcvorlG8nZRn8TDZc8ECQbF/FJQRApT0Vf0Yxf1sdEwpcNO9/o6vnhhEY4KbFbE53xQsx0+QXdQQ+Milg7F8P/lIW9/fFVBSG07kg1qtOpj4LaHxGfwFZwyCWSAvAJ13WIlomCO/HLY3aa07zO3l6jowofJzh3WVHCaGL/Gwg1KuNYS1Hi0Hu0KXwAKeS1YQnkdfaDD7Xvf2TeP3Jzis8iDWyXrZav1XVgtOcDsOkQ3lTkdhunRGyOeqCJrxBvCAiG+N3Lb4h09SJVOIN54lBZAUFRGWjbmawNPfQkTYt8asep/yrLsfokyrBlei6rdacHPQ== avm-unit-test"]
+    }
+  }
+  network_interfaces = {
+    network_interface_1 = {
+      name = "nic-test"
+      ip_configurations = {
+        ip_configuration_1 = {
+          name                          = "nic-test-ipconfig1"
+          private_ip_subnet_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-test/subnets/snet-test"
+        }
+      }
+    }
+  }
+  source_image_reference = {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-focal"
+    sku       = "20_04-lts-gen2"
+    version   = "latest"
+  }
+}
+
+run "os_disk_lock_not_created_by_default" {
+  command = apply
+
+  assert {
+    condition     = length(azurerm_management_lock.this_os_disk) == 0
+    error_message = "The OS disk lock must not be created when os_disk lock_level is not supplied."
+  }
+}
+
+run "os_disk_lock_is_not_inherited_from_the_resource_level_lock" {
+  command = apply
+
+  variables {
+    lock = {
+      kind = "CanNotDelete"
+    }
+  }
+
+  assert {
+    condition     = length(azurerm_management_lock.this_os_disk) == 0
+    error_message = "The OS disk lock must not be inherited from the resource level lock variable."
+  }
+}
+
+run "os_disk_lock_cannot_delete" {
+  command = apply
+
+  variables {
+    os_disk = {
+      caching              = "ReadWrite"
+      storage_account_type = "Premium_LRS"
+      lock_level           = "CanNotDelete"
+    }
+  }
+
+  assert {
+    condition     = length(azurerm_management_lock.this_os_disk) == 1
+    error_message = "The OS disk lock must be created when os_disk lock_level is supplied."
+  }
+  assert {
+    condition     = azurerm_management_lock.this_os_disk[0].lock_level == "CanNotDelete"
+    error_message = "The OS disk lock must use the supplied lock_level."
+  }
+  assert {
+    condition     = azurerm_management_lock.this_os_disk[0].name == "vm-os-disk-lock-os-disk-lock"
+    error_message = "The OS disk lock name must be generated from the virtual machine name when lock_name is not supplied."
+  }
+  assert {
+    condition     = azurerm_management_lock.this_os_disk[0].scope == "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/disks/vm-os-disk-lock-osdisk"
+    error_message = "The OS disk lock must be scoped to the OS disk resource id, not the virtual machine."
+  }
+}
+
+run "os_disk_lock_read_only_with_custom_name" {
+  command = apply
+
+  variables {
+    os_disk = {
+      caching              = "ReadWrite"
+      storage_account_type = "Premium_LRS"
+      lock_level           = "ReadOnly"
+      lock_name            = "custom-os-disk-lock"
+    }
+  }
+
+  assert {
+    condition     = azurerm_management_lock.this_os_disk[0].lock_level == "ReadOnly"
+    error_message = "The OS disk lock must support a ReadOnly lock level."
+  }
+  assert {
+    condition     = azurerm_management_lock.this_os_disk[0].name == "custom-os-disk-lock"
+    error_message = "The OS disk lock must use the supplied lock_name when one is provided."
+  }
+}
+
+run "os_disk_invalid_lock_level_rejected" {
+  #variable validation is evaluated during planning, so the apply can never be reached here.
+  command = plan
+
+  variables {
+    os_disk = {
+      caching              = "ReadWrite"
+      storage_account_type = "Premium_LRS"
+      lock_level           = "None"
+    }
+  }
+
+  expect_failures = [var.os_disk]
+}
+
+run "os_disk_lock_name_requires_lock_level" {
+  #variable validation is evaluated during planning, so the apply can never be reached here.
+  command = plan
+
+  variables {
+    os_disk = {
+      caching              = "ReadWrite"
+      storage_account_type = "Premium_LRS"
+      lock_name            = "orphaned-lock-name"
+    }
+  }
+
+  expect_failures = [var.os_disk]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -968,6 +968,8 @@ variable "os_disk" {
     disk_access_resource_id          = optional(string)
     disk_encryption_set_id           = optional(string)
     disk_size_gb                     = optional(number)
+    lock_level                       = optional(string, null)
+    lock_name                        = optional(string, null)
     name                             = optional(string)
     network_access_policy            = optional(string)
     public_network_access_enabled    = optional(bool)
@@ -991,6 +993,8 @@ Required configuration values for the OS disk on the virtual machine.
 - `disk_access_resource_id`          = (Optional) - The Azure Resource ID of the Disk Access resource to use for private endpoint connectivity to this OS Disk. Only supported when `network_access_policy` is set to `AllowPrivate`. Applied to the OS Disk after the virtual machine has been created.
 - `disk_encryption_set_id`           = (Optional) - The Azure Resource ID of the Disk Encryption Set which should be used to Encrypt this OS Disk. Conflicts with secure_vm_disk_encryption_set_id. The Disk Encryption Set must have the Reader Role Assignment scoped on the Key Vault - in addition to an Access Policy to the Key Vault
 - `disk_size_gb`                     = (Optional) - The Size of the Internal OS Disk in GB, if you wish to vary from the size used in the image this Virtual Machine is sourced from.
+- `lock_level`                       = (Optional) - Set this value to apply a resource lock to the OS Disk. Possible values are `CanNotDelete` and `ReadOnly`. Unlike the resource level `lock` variable, this value is not inherited and must be set explicitly. Note that a `CanNotDelete` lock on the OS Disk will block deletion of the virtual machine, and a `ReadOnly` lock will additionally block operations such as resizing the disk, until the lock is removed.
+- `lock_name`                        = (Optional) - The name for the lock on the OS Disk. If not specified, a name is generated from the virtual machine name.
 - `name`                             = (Optional) - The name which should be used for the Internal OS Disk. Changing this forces a new resource to be created.
 - `network_access_policy`            = (Optional) - Policy for accessing the OS Disk via network. Possible values are `AllowAll`, `AllowPrivate`, and `DenyAll`. Leave unset to keep the Azure default (`AllowAll`). Applied to the OS Disk after the virtual machine has been created.
 - `public_network_access_enabled`    = (Optional) - Should it be allowed to access the OS Disk via the public network? Leave unset to keep the Azure default (`true`). Set to `false` to disable public network access on the OS Disk. Applied to the OS Disk after the virtual machine has been created.
@@ -1037,6 +1041,13 @@ os_disk = {
   network_access_policy         = "AllowPrivate"
   disk_access_resource_id       = azurerm_disk_access.this.id
 }
+
+#protect the os disk from deletion with a resource lock
+os_disk = {
+  caching              = "ReadWrite"
+  storage_account_type = "Premium_LRS"
+  lock_level           = "CanNotDelete"
+}
 ```
 OS_DISK
   nullable    = false
@@ -1048,6 +1059,14 @@ OS_DISK
   validation {
     condition     = var.os_disk.disk_access_resource_id == null ? true : var.os_disk.network_access_policy == "AllowPrivate"
     error_message = "The os_disk disk_access_resource_id can only be set when the os_disk network_access_policy is set to `AllowPrivate`."
+  }
+  validation {
+    condition     = var.os_disk.lock_level == null ? true : contains(["CanNotDelete", "ReadOnly"], var.os_disk.lock_level)
+    error_message = "The os_disk lock_level must be either `CanNotDelete` or `ReadOnly`."
+  }
+  validation {
+    condition     = var.os_disk.lock_name == null ? true : var.os_disk.lock_level != null
+    error_message = "The os_disk lock_name can only be set when the os_disk lock_level is also set."
   }
 }
 


### PR DESCRIPTION
## Description

Adds resource lock support for the **OS disk**. The module already supports locks on the VM, NICs, public IPs and data disks — the OS disk was the remaining gap.

Two new optional attributes on the `os_disk` input, named to match `data_disk_managed_disks` and `network_interfaces`:

| Attribute | Description |
|---|---|
| `lock_level` | `CanNotDelete` or `ReadOnly`. |
| `lock_name` | Optional lock name; defaults to `"<vm name>-os-disk-lock"`. |

**Context:** the OS disk is an inline block on `azurerm_linux_virtual_machine` / `azurerm_windows_virtual_machine`, not a separate `azurerm_managed_disk`, so there is no resource to attach a lock to directly. Rather than hand-building the disk ARM ID from `os_disk.name` (which would require `name` to be set), the module reads the computed `os_disk[0].id` back off the created VM and scopes an `azurerm_management_lock` to it. This works whether or not `os_disk.name` is supplied.

`depends_on` covers the VM, data disk attachments and extensions, so the disk is fully provisioned before a lock is applied — a `ReadOnly` lock would otherwise block subsequent writes.

**Backwards compatible:** both attributes default to `null`. When `lock_level` is unset the lock resource has `count = 0` and nothing changes for existing consumers. Consistent with data disks and NICs, the OS disk lock is **not** inherited from the resource level `var.lock` and must be set explicitly.

Two validation rules were added: `lock_level` must be `CanNotDelete` or `ReadOnly` (same rule as `var.lock`), and `lock_name` cannot be set without `lock_level`.

> Note: no example was added because a `CanNotDelete`/`ReadOnly` lock would block the destroy step of the e2e example tests. The operational impact of each lock level is documented on the input instead.

No new dependencies.

Closes #243

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks
