### PR TITLE
fix: skip remaining osProfile attributes in OS disk attach mode (409 on import)

### DIFF
--- a/main.linux_vm.tf
+++ b/main.linux_vm.tf
@@ -11,7 +11,7 @@ resource "azurerm_linux_virtual_machine" "this" {
   admin_password = local.os_disk_is_imported ? null : (local.password_authentication_disabled ? null : local.admin_password_linux)
   #required properties (admin_username is null when using os_managed_disk_id per Provider ExactlyOneOf constraint)
   admin_username                                         = local.admin_username
-  allow_extension_operations                             = var.allow_extension_operations
+  allow_extension_operations                             = local.os_disk_is_imported ? null : var.allow_extension_operations
   availability_set_id                                    = var.availability_set_resource_id
   bypass_platform_safety_checks_on_user_schedule_enabled = local.os_disk_is_imported ? null : var.bypass_platform_safety_checks_on_user_schedule_enabled
   capacity_reservation_group_id                          = var.capacity_reservation_group_resource_id
@@ -19,7 +19,7 @@ resource "azurerm_linux_virtual_machine" "this" {
   custom_data                                            = local.os_disk_is_imported ? null : var.custom_data
   dedicated_host_group_id                                = var.dedicated_host_group_resource_id
   dedicated_host_id                                      = var.dedicated_host_resource_id
-  disable_password_authentication                        = local.password_authentication_disabled
+  disable_password_authentication                        = local.os_disk_is_imported ? null : local.password_authentication_disabled
   disk_controller_type                                   = var.disk_controller_type
   edge_zone                                              = var.edge_zone
   encryption_at_host_enabled                             = var.encryption_at_host_enabled

--- a/main.windows_vm.tf
+++ b/main.windows_vm.tf
@@ -11,7 +11,7 @@ resource "azurerm_windows_virtual_machine" "this" {
   admin_password = local.os_disk_is_imported ? null : local.admin_password_windows
   admin_username = local.admin_username
   #optional properties
-  allow_extension_operations                             = var.allow_extension_operations
+  allow_extension_operations                             = local.os_disk_is_imported ? null : var.allow_extension_operations
   automatic_updates_enabled                              = local.os_disk_is_imported ? null : local.automatic_updates_enabled
   availability_set_id                                    = var.availability_set_resource_id
   bypass_platform_safety_checks_on_user_schedule_enabled = local.os_disk_is_imported ? null : var.bypass_platform_safety_checks_on_user_schedule_enabled

--- a/tests/unit/os_disk_attach_mode.tftest.hcl
+++ b/tests/unit/os_disk_attach_mode.tftest.hcl
@@ -1,0 +1,146 @@
+# Attach mode (os_disk_attach_mode / os_managed_disk_id) VMs have no osProfile in Azure, so the
+# module must not send any osProfile derived attribute. The provider marks those attributes
+# Optional+Computed, which means the mocked provider fills them from the `defaults` below whenever
+# the module leaves them null. The defaults are therefore deliberately the opposite of the values
+# fed in through `variables`, so a value that leaks through the guard is distinguishable from a
+# value that was correctly nulled out.
+mock_provider "azapi" {}
+mock_provider "azurerm" {
+  mock_resource "azurerm_network_interface" {
+    defaults = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/networkInterfaces/nic-test"
+    }
+  }
+
+  mock_resource "azurerm_linux_virtual_machine" {
+    defaults = {
+      allow_extension_operations      = true
+      disable_password_authentication = true
+      os_disk = {
+        id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/disks/vm-attach-mode-osdisk"
+      }
+    }
+  }
+
+  mock_resource "azurerm_windows_virtual_machine" {
+    defaults = {
+      allow_extension_operations = true
+      os_disk = {
+        id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/disks/vm-attach-mode-osdisk"
+      }
+    }
+  }
+}
+mock_provider "modtm" {}
+mock_provider "random" {
+  #the generated value has to satisfy the provider side complexity check on admin_password.
+  mock_resource "random_password" {
+    defaults = {
+      result = "avmUnitTest123!"
+    }
+  }
+}
+mock_provider "tls" {}
+
+variables {
+  location            = "eastus"
+  name                = "vm-attach-mode"
+  resource_group_name = "rg-test"
+  zone                = "1"
+  os_type             = "Linux"
+  #the sentinel input value - the mocked provider defaults above use the opposite value.
+  allow_extension_operations = false
+  network_interfaces = {
+    network_interface_1 = {
+      name = "nic-test"
+      ip_configurations = {
+        ip_configuration_1 = {
+          name                          = "nic-test-ipconfig1"
+          private_ip_subnet_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-test/subnets/snet-test"
+        }
+      }
+    }
+  }
+  source_image_reference = {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-focal"
+    sku       = "20_04-lts-gen2"
+    version   = "latest"
+  }
+}
+
+run "linux_attach_mode_omits_os_profile_attributes" {
+  command = apply
+
+  variables {
+    os_disk_attach_mode = true
+    os_managed_disk_id  = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/disks/disk-test"
+    account_credentials = {
+      admin_credentials = {
+        generate_admin_password_or_ssh_key = true
+      }
+      password_authentication_disabled = false
+    }
+  }
+
+  assert {
+    condition     = azurerm_linux_virtual_machine.this[0].allow_extension_operations == true
+    error_message = "allow_extension_operations must not be sent in attach mode - updating it rewrites osProfile, which Azure rejects with 409 PropertyChangeNotAllowed on an imported VM."
+  }
+  assert {
+    condition     = azurerm_linux_virtual_machine.this[0].disable_password_authentication == true
+    error_message = "disable_password_authentication must not be sent in attach mode - it is part of osProfile and is ForceNew, so an imported VM would be planned for replacement."
+  }
+}
+
+run "linux_without_attach_mode_honours_os_profile_attributes" {
+  command = apply
+
+  variables {
+    os_disk_attach_mode = false
+    account_credentials = {
+      admin_credentials = {
+        generate_admin_password_or_ssh_key = true
+      }
+      password_authentication_disabled = false
+    }
+  }
+
+  assert {
+    condition     = azurerm_linux_virtual_machine.this[0].allow_extension_operations == false
+    error_message = "allow_extension_operations must still be taken from the input variable when attach mode is not in use."
+  }
+  assert {
+    condition     = azurerm_linux_virtual_machine.this[0].disable_password_authentication == false
+    error_message = "disable_password_authentication must still be taken from the credential inputs when attach mode is not in use."
+  }
+}
+
+run "windows_attach_mode_omits_os_profile_attributes" {
+  command = apply
+
+  variables {
+    os_type             = "Windows"
+    os_disk_attach_mode = true
+    os_managed_disk_id  = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/disks/disk-test"
+  }
+
+  assert {
+    condition     = azurerm_windows_virtual_machine.this[0].allow_extension_operations == true
+    error_message = "allow_extension_operations must not be sent in attach mode - updating it rewrites osProfile, which Azure rejects with 409 PropertyChangeNotAllowed on an imported VM."
+  }
+}
+
+run "windows_without_attach_mode_honours_os_profile_attributes" {
+  command = apply
+
+  variables {
+    os_type             = "Windows"
+    os_disk_attach_mode = false
+  }
+
+  assert {
+    condition     = azurerm_windows_virtual_machine.this[0].allow_extension_operations == false
+    error_message = "allow_extension_operations must still be taken from the input variable when attach mode is not in use."
+  }
+}


### PR DESCRIPTION
## Description

Attach mode VMs (`os_disk_attach_mode` / `os_managed_disk_id`) have **no `osProfile`** in Azure, so any update touching it is rejected with `409 PropertyChangeNotAllowed`.

On *create* the SDK retains config values in state even when the provider's `Read` never sets them, which is why `examples/linux_os_managed_disk` is unaffected. On *import* the resource state starts empty, so every `osProfile` attribute the module still hardcodes is planned as a change on the first apply.

#234 nulled out most of them. Two were still unguarded:

| Attribute | Files | Provider schema (>= 4.42) | Result on import |
|---|---|---|---|
| `allow_extension_operations` | Linux + Windows | `Optional + Computed` | planned `true` -> rewrites `osProfile` -> **409** (reported in #240) |
| `disable_password_authentication` | Linux | `Optional + Computed + ForceNew` | planned `true` -> imported VM planned for **replacement** |

The provider annotates both with `// O+C OsProfile vs os_managed_disk_id`, i.e. its contract is "do not set these when `os_managed_disk_id` is in play", which maps exactly onto the existing `local.os_disk_is_imported ? null : ...` guard. Both are `Optional + Computed` as of azurerm `4.42`, which is already the module floor, so no provider constraint bump is needed.

Because a null config on an `Optional + Computed` attribute retains the prior state value, **already-created VMs see no drift** and the non-attach code path is unchanged.

### Note on `bypass_platform_safety_checks_on_user_schedule_enabled`

It appears in the issue's plan output as `+ false`, but it has `Default: false` in the provider and SDKv2 shims a missing bool in prior state to `false`, so `d.HasChange` is false and no `osProfile` update is sent. It is cosmetic only and needs no further change.

### Relationship to #241

This is an alternative to #241, which fixes the same issue by adding `allow_extension_operations` and `bypass_platform_safety_checks_on_user_schedule_enabled` to `ignore_changes`. `ignore_changes` is static, so that approach would stop *every* VM - not just attach mode ones - from honouring day-2 changes to those inputs. The null guard here is scoped to attach mode only. Thanks to @mikedembek for the original diagnosis and PR.

## Testing

New `tests/unit/os_disk_attach_mode.tftest.hcl` with 4 run blocks (Linux/Windows x attach mode on/off). The mocked provider defaults are deliberately the inverse of the inputs, so a value leaking through the guard is distinguishable from one correctly nulled out.

- `terraform test -test-directory ./tests/unit` -> 11 passed, 0 failed
- Mutation check: reverting the three guards makes exactly the three attach mode assertions fail while the pass-through assertions still pass
- `terraform fmt -check -recursive` and `terraform validate` clean

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #240" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all pre-commit checks (Docker was unavailable locally, so `terraform fmt`, `validate` and `test` were run directly; `tflint` / `terraform-docs` are left to CI - no variable or output changes, so generated docs are unchanged)

Closes #240

