### PR TITLE
fix: manage Azure Backup protected item lifecycle explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@
 
 This is the virtual machine resource module for the Azure Verified Modules library.  This module deploys a Windows and/or Linux virtual machine along with common associated resources.  It leverages the AzureRM provider and sets a number of initial defaults to minimize the overall inputs for simple configurations.
 
+## Azure Backup lifecycle
+
+The module manages each configured Azure VM backup protected item through its full lifecycle:
+
+- A missing protected item is created.
+- An existing active or `ProtectionStopped` item is adopted and updated.
+- A soft-deleted item is automatically rehydrated before its backup configuration is applied.
+- Existing protected items managed by earlier module versions are adopted without deleting their recovery points.
+
+By default, removing a backup configuration or destroying the module deletes the protected item, matching the module's previous behavior. Set `retain_backup_data_on_destroy = true` on an `azure_backup_configurations` entry to stop protection while retaining its recovery points. This mode is intended for immutable vaults and other scenarios where backup data must outlive the virtual machine. Retained recovery points can continue to incur charges until they expire or are deleted.
+
 <!-- markdownlint-disable MD033 -->
 ## Requirements
 
@@ -13,7 +24,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.10, < 2.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.4)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 4.42, < 5.0)
 
@@ -27,8 +38,10 @@ The following requirements are needed by this module:
 
 The following resources are used by this module:
 
-- [azapi_resource.this_backup_intent](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
 - [azapi_resource.this_maintenance_configuration_assignment](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
+- [azapi_resource_action.backup_destroy](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource_action) (resource)
+- [azapi_resource_action.backup_ensure_active](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource_action) (resource)
+- [azapi_update_resource.backup_protection](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/update_resource) (resource)
 - [azapi_update_resource.this_os_disk_network_access](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/update_resource) (resource)
 - [azurerm_dev_test_global_vm_shutdown_schedule.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dev_test_global_vm_shutdown_schedule) (resource)
 - [azurerm_key_vault_secret.admin_password](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) (resource)
@@ -63,6 +76,7 @@ The following resources are used by this module:
 - [random_uuid.telemetry](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) (resource)
 - [tls_private_key.this](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) (resource)
 - [azapi_client_config.telemetry](https://registry.terraform.io/providers/Azure/azapi/latest/docs/data-sources/client_config) (data source)
+- [azapi_resource.backup_item](https://registry.terraform.io/providers/Azure/azapi/latest/docs/data-sources/resource) (data source)
 - [modtm_module_source.telemetry](https://registry.terraform.io/providers/Azure/modtm/latest/docs/data-sources/module_source) (data source)
 
 <!-- markdownlint-disable MD013 -->
@@ -284,35 +298,38 @@ Default: `null`
 
 Description: This object describes the backup configuration to use for this VM instance. Provide the backup details for configuring the backup. It defaults to null.
 
-- `<map_key>` - An arbitrary map key to avoid terraform issues with know before apply challenges
-  - `recovery_vault_resource_id - (Required) - The Azure Resource ID of the recovery services vault where the backup will be stored.
-  - `resource\_group\_name` - (Optional) - This value is deprecated and will be removed in future versions as the VM resource group name will be used.
-  - `recovery\_vault\_name` - (Optional) - This value is deprecated and will be removed in future versions as the RSV information will be pulled from the RSV resource id. The name of the recovery services vault where the backup will be stored.
-  - `backup\_policy\_resource\_id` - (Optional) - Required during creation, but can be optional when the protection state is not `ProtectionStopped`.
-  - `exclude\_disk\_luns`   - (Optional) - A list of Disk Logical Unit Numbers (LUN) to be excluded from VM Protection. Only one of `exclude\_disk\_luns` or `include\_disk\_luns` can be set. If both are set then only the `exclude\_disk\_luns` value will be used.
-  - `include\_disk\_luns`   - (Optional) - A list of Disk Logical Unit Numbers (LUN) to be included for VM Protection. Only one of `exclude\_disk\_luns` or `include\_disk\_luns` can be set. If both are set then only the `exclude\_disk\_luns` value will be used.
+- `<map_key>` - An arbitrary map key to avoid Terraform issues with values that must be known before apply.
+  - `recovery_vault_resource_id` - (Required) - The Azure Resource ID of the recovery services vault where the backup will be stored. Changing the vault causes the old protected item to follow the configured destroy behavior: it is deleted by default or retained when `retain_backup_data_on_destroy` is `true`.
+  - `resource_group_name` - (Optional) - This value is deprecated and will be removed in future versions as the VM resource group name will be used.
+  - `recovery_vault_name` - (Optional) - This value is deprecated and will be removed in future versions as the RSV information will be pulled from the RSV resource id. The name of the recovery services vault where the backup will be stored.
+  - `backup_policy_resource_id` - (Optional) - Required during creation, but can be optional when the protection state is not `ProtectionStopped`.
+  - `exclude_disk_luns`   - (Optional) - A list of Disk Logical Unit Numbers (LUN) to be excluded from VM Protection. Only one of `exclude_disk_luns` or `include_disk_luns` can be set. If both are set then only the `exclude_disk_luns` value will be used.
+  - `include_disk_luns`   - (Optional) - A list of Disk Logical Unit Numbers (LUN) to be included for VM Protection. Only one of `exclude_disk_luns` or `include_disk_luns` can be set. If both are set then only the `exclude_disk_luns` value will be used.
+  - `retain_backup_data_on_destroy` - (Optional) - When `true`, destroying the module stops protection and retains the existing recovery points instead of deleting the protected item. Use this for immutable vaults or whenever backup data must outlive the VM. Retained backup data can continue to incur charges. Defaults to `false`.
 
-Example Input:  
-azure_backup_configurations = {  
-  arbitrary_key = {  
-    recovery_vault_resource_id = azurerm_recovery_services_vault.test_vault.id  
-    backup_policy_resource_id    = azurerm_backup_policy_vm.test_policy.id  
-    exclude_disk_luns   = [0,1]
+Example Input:
+```hcl
+azure_backup_configurations = {
+  arbitrary_key = {
+    recovery_vault_resource_id    = azurerm_recovery_services_vault.test_vault.id
+    backup_policy_resource_id     = azurerm_backup_policy_vm.test_policy.id
+    exclude_disk_luns             = [0, 1]
+    retain_backup_data_on_destroy = true
   }
 }
-`
+```
 
 Type:
 
 ```hcl
 map(object({
-    resource_group_name        = optional(string, null)
-    recovery_vault_name        = optional(string, null)
-    recovery_vault_resource_id = string
-    backup_policy_resource_id  = optional(string, null)
-    exclude_disk_luns          = optional(list(number), null)
-    include_disk_luns          = optional(list(number), null)
-
+    resource_group_name           = optional(string, null)
+    recovery_vault_name           = optional(string, null)
+    recovery_vault_resource_id    = string
+    backup_policy_resource_id     = optional(string, null)
+    exclude_disk_luns             = optional(list(number), null)
+    include_disk_luns             = optional(list(number), null)
+    retain_backup_data_on_destroy = optional(bool, false)
   }))
 ```
 

--- a/_header.md
+++ b/_header.md
@@ -3,3 +3,14 @@
 ### NOTE: This module follows the semantic versioning and versions prior to 1.0.0 should be considered pre-release versions. This v0.19.0 version contains a number of breaking changes and is intended to be the final signficant release prior to the v1.0.0 release.  Please review the release notes prior to updating previous deployments to use this version.
 
 This is the virtual machine resource module for the Azure Verified Modules library.  This module deploys a Windows and/or Linux virtual machine along with common associated resources.  It leverages the AzureRM provider and sets a number of initial defaults to minimize the overall inputs for simple configurations.
+
+## Azure Backup lifecycle
+
+The module manages each configured Azure VM backup protected item through its full lifecycle:
+
+- A missing protected item is created.
+- An existing active or `ProtectionStopped` item is adopted and updated.
+- A soft-deleted item is automatically rehydrated before its backup configuration is applied.
+- Existing protected items managed by earlier module versions are adopted without deleting their recovery points.
+
+By default, removing a backup configuration or destroying the module deletes the protected item, matching the module's previous behavior. Set `retain_backup_data_on_destroy = true` on an `azure_backup_configurations` entry to stop protection while retaining its recovery points. This mode is intended for immutable vaults and other scenarios where backup data must outlive the virtual machine. Retained recovery points can continue to incur charges until they expire or are deleted.

--- a/examples/windows_w_backup/.e2eignore
+++ b/examples/windows_w_backup/.e2eignore
@@ -1,1 +1,0 @@
-# Ignore this example in the e2e tests because resource deletion will fail due to Vault soft delete.

--- a/examples/windows_w_backup/README.md
+++ b/examples/windows_w_backup/README.md
@@ -221,9 +221,9 @@ resource "azapi_resource" "test_vault" {
       publicNetworkAccess = "Enabled"
       securitySettings = {
         softDeleteSettings = {
-          enhancedSecurityState           = "Disabled"
-          softDeleteRetentionPeriodInDays = 0
-          softDeleteState                 = "Disabled"
+          enhancedSecurityState           = "Enabled"
+          softDeleteRetentionPeriodInDays = 14
+          softDeleteState                 = "Enabled"
         }
       }
       restoreSettings = {

--- a/examples/windows_w_backup/README.md
+++ b/examples/windows_w_backup/README.md
@@ -162,6 +162,7 @@ resource "azurerm_public_ip" "bastionpip" {
   name                = "${module.naming.public_ip.name_unique}-bastion"
   resource_group_name = azurerm_resource_group.this_rg.name
   sku                 = "Standard"
+  zones               = module.regions.regions_by_name[local.deployment_region].zones
 }
 
 resource "azurerm_bastion_host" "bastion" {

--- a/examples/windows_w_backup/main.tf
+++ b/examples/windows_w_backup/main.tf
@@ -140,6 +140,7 @@ resource "azurerm_public_ip" "bastionpip" {
   name                = "${module.naming.public_ip.name_unique}-bastion"
   resource_group_name = azurerm_resource_group.this_rg.name
   sku                 = "Standard"
+  zones               = module.regions.regions_by_name[local.deployment_region].zones
 }
 
 resource "azurerm_bastion_host" "bastion" {

--- a/examples/windows_w_backup/main.tf
+++ b/examples/windows_w_backup/main.tf
@@ -199,9 +199,9 @@ resource "azapi_resource" "test_vault" {
       publicNetworkAccess = "Enabled"
       securitySettings = {
         softDeleteSettings = {
-          enhancedSecurityState           = "Disabled"
-          softDeleteRetentionPeriodInDays = 0
-          softDeleteState                 = "Disabled"
+          enhancedSecurityState           = "Enabled"
+          softDeleteRetentionPeriodInDays = 14
+          softDeleteState                 = "Enabled"
         }
       }
       restoreSettings = {

--- a/main.backup.tf
+++ b/main.backup.tf
@@ -1,21 +1,3 @@
-/* Leaving this in case we have to revert the azAPI changes.
-resource "azurerm_backup_protected_vm" "this" {
-  for_each = var.azure_backup_configurations
-
-  recovery_vault_name = each.value.recovery_vault_name
-  resource_group_name = coalesce(each.value.resource_group_name, var.resource_group_name)
-  backup_policy_id    = each.value.backup_policy_resource_id
-  exclude_disk_luns   = each.value.exclude_disk_luns
-  include_disk_luns   = each.value.include_disk_luns
-  #protection_state    = each.value.protection_state
-  source_vm_id        = local.virtualmachine_resource_id
-
-  depends_on = [
-    azurerm_virtual_machine_data_disk_attachment.this_linux,
-    azurerm_virtual_machine_data_disk_attachment.this_windows
-  ]
-}
-*/
 locals {
   backup_body_extended_properties = { for key, value in var.azure_backup_configurations : key => try(length(value.exclude_disk_luns) > 0, false) ? {
     extendedProperties = {
@@ -42,27 +24,113 @@ locals {
     policyName        = basename(value.backup_policy_resource_id)
     }
   }
-  rsv_resource_group = { for key, value in var.azure_backup_configurations : key => try(split("/", split("resourceGroups/", value.recovery_vault_resource_id)[1])[0], null) }
+  backup_item_is_soft_deleted = {
+    for key, value in var.azure_backup_configurations : key => data.azapi_resource.backup_item[key].exists && try(
+      data.azapi_resource.backup_item[key].output.properties.isScheduledForDeferredDelete == true,
+      false
+    )
+  }
+  backup_item_resource_ids = {
+    for key, value in var.azure_backup_configurations : key => "${value.recovery_vault_resource_id}/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasvmcontainerv2;${var.resource_group_name};${var.name}/protectedItems/VM;iaasvmcontainerv2;${var.resource_group_name};${var.name}"
+  }
+  backup_protected_item_resource_type = "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems@2024-10-01"
 }
 
-resource "azapi_resource" "this_backup_intent" {
+data "azapi_resource" "backup_item" {
   for_each = var.azure_backup_configurations
 
-  name      = "VM;iaasvmcontainerv2;${coalesce(var.resource_group_name, each.value.resource_group_name, local.rsv_resource_group[each.key])};${var.name}"
-  parent_id = "${each.value.recovery_vault_resource_id}/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasvmcontainerv2;${var.resource_group_name};${var.name}"
-  type      = "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems@2024-10-01"
+  resource_id            = local.backup_item_resource_ids[each.key]
+  type                   = local.backup_protected_item_resource_type
+  headers                = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_not_found       = true
+  response_export_values = ["properties.isScheduledForDeferredDelete"]
+}
+
+# A protected item can be absent, active, stopped, or soft-deleted. A PUT creates or resumes the
+# first three states; a soft-deleted item must be rehydrated before its configuration can be updated.
+resource "azapi_resource_action" "backup_ensure_active" {
+  for_each = var.azure_backup_configurations
+
+  method      = "PUT"
+  resource_id = local.backup_item_resource_ids[each.key]
+  type        = local.backup_protected_item_resource_type
+  body = jsondecode(local.backup_item_is_soft_deleted[each.key] ? jsonencode({
+    properties = {
+      isRehydrate       = true
+      protectedItemType = "Microsoft.Compute/virtualMachines"
+    }
+    }) : jsonencode({
+    properties = local.backup_body_properties[each.key]
+  }))
+  headers                = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  locks                  = [local.backup_item_resource_ids[each.key]]
+  response_export_values = []
+  when                   = "apply"
+
+  depends_on = [
+    azurerm_virtual_machine_data_disk_attachment.this_linux,
+    azurerm_virtual_machine_data_disk_attachment.this_windows
+  ]
+}
+
+# Manage the declared backup properties after the create/resume/rehydrate operation. Unlike
+# azapi_resource, deleting azapi_update_resource performs no remote operation; teardown behavior is
+# handled explicitly by backup_destroy below.
+resource "azapi_update_resource" "backup_protection" {
+  for_each = var.azure_backup_configurations
+
+  resource_id = local.backup_item_resource_ids[each.key]
+  type        = local.backup_protected_item_resource_type
   body = {
     properties = local.backup_body_properties[each.key]
   }
-  create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
-  delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   ignore_casing          = true
+  locks                  = [local.backup_item_resource_ids[each.key]]
   read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
-  response_export_values = ["*"]
+  response_export_values = []
   update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+
+  depends_on = [azapi_resource_action.backup_ensure_active]
 }
 
-moved {
+# The Backup API uses PUT ProtectionStopped to retain recovery points and DELETE to remove them.
+# Modeling the destroy request separately avoids azapi_resource's unconditional DELETE behavior.
+resource "azapi_resource_action" "backup_destroy" {
+  for_each = var.azure_backup_configurations
+
+  method      = each.value.retain_backup_data_on_destroy ? "PUT" : "DELETE"
+  resource_id = local.backup_item_resource_ids[each.key]
+  type        = local.backup_protected_item_resource_type
+  body = each.value.retain_backup_data_on_destroy ? {
+    properties = {
+      protectedItemType = "Microsoft.Compute/virtualMachines"
+      protectionState   = "ProtectionStopped"
+      sourceResourceId  = local.virtualmachine_resource_id
+    }
+  } : null
+  headers                = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_not_found       = true
+  locks                  = [local.backup_item_resource_ids[each.key]]
+  response_export_values = []
+  when                   = "destroy"
+
+  depends_on = [azapi_update_resource.backup_protection]
+}
+
+# Previous module versions used both resource types below. Forget their state entries without
+# issuing a remote delete; the lifecycle resources above inspect and adopt the existing item.
+removed {
+  from = azapi_resource.this_backup_intent
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
   from = azurerm_backup_protected_vm.this
-  to   = azapi_resource.this_backup_intent
+
+  lifecycle {
+    destroy = false
+  }
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.4"
+      version = "~> 2.9"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/tests/unit/backup_lifecycle.tftest.hcl
+++ b/tests/unit/backup_lifecycle.tftest.hcl
@@ -1,0 +1,191 @@
+mock_provider "azapi" {
+  mock_data "azapi_resource" {
+    defaults = {
+      exists = false
+      output = null
+    }
+  }
+}
+mock_provider "azurerm" {
+  mock_resource "azurerm_network_interface" {
+    defaults = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/networkInterfaces/nic-test"
+    }
+  }
+
+  mock_resource "azurerm_windows_virtual_machine" {
+    defaults = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/virtualMachines/vm-backup"
+      os_disk = {
+        id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/disks/vm-backup-osdisk"
+      }
+    }
+  }
+}
+mock_provider "modtm" {}
+mock_provider "random" {
+  mock_resource "random_password" {
+    defaults = {
+      result = "avmUnitTest123!"
+    }
+  }
+}
+mock_provider "tls" {}
+
+variables {
+  location            = "eastus"
+  name                = "vm-backup"
+  resource_group_name = "rg-test"
+  zone                = "1"
+  os_type             = "Windows"
+  azure_backup_configurations = {
+    main = {
+      recovery_vault_resource_id = "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/rg-backup/providers/Microsoft.RecoveryServices/vaults/rsv-test"
+      backup_policy_resource_id  = "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/rg-backup/providers/Microsoft.RecoveryServices/vaults/rsv-test/backupPolicies/policy-test"
+    }
+  }
+  network_interfaces = {
+    network_interface_1 = {
+      name = "nic-test"
+      ip_configurations = {
+        ip_configuration_1 = {
+          name                          = "nic-test-ipconfig1"
+          private_ip_subnet_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-test/subnets/snet-test"
+        }
+      }
+    }
+  }
+  source_image_reference = {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2022-datacenter-g2"
+    version   = "latest"
+  }
+}
+
+run "missing_backup_item_is_created" {
+  command = apply
+
+  assert {
+    condition     = data.azapi_resource.backup_item["main"].ignore_not_found
+    error_message = "The backup item lookup must tolerate a missing protected item during initial creation."
+  }
+  assert {
+    condition     = azapi_resource_action.backup_ensure_active["main"].method == "PUT"
+    error_message = "A missing backup item must be created with a PUT request."
+  }
+  assert {
+    condition     = azapi_resource_action.backup_ensure_active["main"].body.properties.policyId == "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/rg-backup/providers/Microsoft.RecoveryServices/vaults/rsv-test/backupPolicies/policy-test"
+    error_message = "The create request must contain the configured backup policy."
+  }
+  assert {
+    condition     = azapi_update_resource.backup_protection["main"].body.properties.sourceResourceId == "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/virtualMachines/vm-backup"
+    error_message = "The managed backup configuration must reference the virtual machine resource ID."
+  }
+  assert {
+    condition     = azapi_resource_action.backup_destroy["main"].method == "DELETE"
+    error_message = "The default destroy behavior must continue to delete the protected item."
+  }
+  assert {
+    condition     = azapi_resource_action.backup_destroy["main"].resource_id == "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/rg-backup/providers/Microsoft.RecoveryServices/vaults/rsv-test/backupFabrics/Azure/protectionContainers/iaasvmcontainer;iaasvmcontainerv2;rg-test;vm-backup/protectedItems/VM;iaasvmcontainerv2;rg-test;vm-backup"
+    error_message = "The protected item resource ID must support a vault in a different subscription from the VM."
+  }
+}
+
+run "soft_deleted_backup_item_is_rehydrated" {
+  command = apply
+
+  override_data {
+    target = data.azapi_resource.backup_item["main"]
+    values = {
+      exists = true
+      output = {
+        properties = {
+          isScheduledForDeferredDelete = true
+        }
+      }
+    }
+  }
+
+  assert {
+    condition     = azapi_resource_action.backup_ensure_active["main"].body.properties.isRehydrate
+    error_message = "A soft-deleted protected item must be rehydrated before its backup configuration is applied."
+  }
+  assert {
+    condition     = azapi_resource_action.backup_ensure_active["main"].body.properties.protectedItemType == "Microsoft.Compute/virtualMachines"
+    error_message = "The rehydrate request must include the protectedItemType discriminator required by the Backup API."
+  }
+  assert {
+    condition     = azapi_update_resource.backup_protection["main"].body.properties.policyId == "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/rg-backup/providers/Microsoft.RecoveryServices/vaults/rsv-test/backupPolicies/policy-test"
+    error_message = "The full backup configuration must be managed after rehydrating a soft-deleted item."
+  }
+}
+
+run "active_backup_item_is_adopted" {
+  command = apply
+
+  override_data {
+    target = data.azapi_resource.backup_item["main"]
+    values = {
+      exists = true
+      output = {
+        properties = {
+          isScheduledForDeferredDelete = false
+        }
+      }
+    }
+  }
+
+  assert {
+    condition     = azapi_resource_action.backup_ensure_active["main"].body.properties.policyId == "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/rg-backup/providers/Microsoft.RecoveryServices/vaults/rsv-test/backupPolicies/policy-test"
+    error_message = "An existing active or ProtectionStopped item must be adopted with the full backup configuration rather than rehydrated."
+  }
+}
+
+run "backup_data_can_be_retained_on_destroy" {
+  command = apply
+
+  variables {
+    azure_backup_configurations = {
+      main = {
+        recovery_vault_resource_id    = "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/rg-backup/providers/Microsoft.RecoveryServices/vaults/rsv-test"
+        backup_policy_resource_id     = "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/rg-backup/providers/Microsoft.RecoveryServices/vaults/rsv-test/backupPolicies/policy-test"
+        retain_backup_data_on_destroy = true
+      }
+    }
+  }
+
+  assert {
+    condition     = azapi_resource_action.backup_destroy["main"].method == "PUT"
+    error_message = "Retaining backup data must use a PUT instead of deleting the protected item."
+  }
+  assert {
+    condition     = azapi_resource_action.backup_destroy["main"].body.properties.protectionState == "ProtectionStopped"
+    error_message = "Retaining backup data must stop protection while preserving recovery points."
+  }
+  assert {
+    condition     = azapi_resource_action.backup_destroy["main"].body.properties.sourceResourceId == "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/virtualMachines/vm-backup"
+    error_message = "The stop-protection request must identify the protected virtual machine."
+  }
+}
+
+run "backup_resources_are_not_created_without_configuration" {
+  command = apply
+
+  variables {
+    azure_backup_configurations = {}
+  }
+
+  assert {
+    condition     = length(azapi_resource_action.backup_ensure_active) == 0
+    error_message = "Backup lifecycle resources must not be created when no backup configuration is supplied."
+  }
+  assert {
+    condition     = length(azapi_update_resource.backup_protection) == 0
+    error_message = "Backup drift management must not be created when no backup configuration is supplied."
+  }
+  assert {
+    condition     = length(azapi_resource_action.backup_destroy) == 0
+    error_message = "Backup destroy actions must not be created when no backup configuration is supplied."
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -218,35 +218,39 @@ variable "availability_set_resource_id" {
 
 variable "azure_backup_configurations" {
   type = map(object({
-    resource_group_name        = optional(string, null)
-    recovery_vault_name        = optional(string, null)
-    recovery_vault_resource_id = string
-    backup_policy_resource_id  = optional(string, null)
-    exclude_disk_luns          = optional(list(number), null)
-    include_disk_luns          = optional(list(number), null)
-
+    resource_group_name           = optional(string, null)
+    recovery_vault_name           = optional(string, null)
+    recovery_vault_resource_id    = string
+    backup_policy_resource_id     = optional(string, null)
+    exclude_disk_luns             = optional(list(number), null)
+    include_disk_luns             = optional(list(number), null)
+    retain_backup_data_on_destroy = optional(bool, false)
   }))
   default     = {}
   description = <<DESCRIPTION
 This object describes the backup configuration to use for this VM instance. Provide the backup details for configuring the backup. It defaults to null.
 
-- `<map_key>` - An arbitrary map key to avoid terraform issues with know before apply challenges
-  - `recovery_vault_resource_id - (Required) - The Azure Resource ID of the recovery services vault where the backup will be stored.
+- `<map_key>` - An arbitrary map key to avoid Terraform issues with values that must be known before apply.
+  - `recovery_vault_resource_id` - (Required) - The Azure Resource ID of the recovery services vault where the backup will be stored. Changing the vault causes the old protected item to follow the configured destroy behavior: it is deleted by default or retained when `retain_backup_data_on_destroy` is `true`.
   - `resource_group_name` - (Optional) - This value is deprecated and will be removed in future versions as the VM resource group name will be used.
   - `recovery_vault_name` - (Optional) - This value is deprecated and will be removed in future versions as the RSV information will be pulled from the RSV resource id. The name of the recovery services vault where the backup will be stored.
   - `backup_policy_resource_id` - (Optional) - Required during creation, but can be optional when the protection state is not `ProtectionStopped`.
   - `exclude_disk_luns`   - (Optional) - A list of Disk Logical Unit Numbers (LUN) to be excluded from VM Protection. Only one of `exclude_disk_luns` or `include_disk_luns` can be set. If both are set then only the `exclude_disk_luns` value will be used.
   - `include_disk_luns`   - (Optional) - A list of Disk Logical Unit Numbers (LUN) to be included for VM Protection. Only one of `exclude_disk_luns` or `include_disk_luns` can be set. If both are set then only the `exclude_disk_luns` value will be used.
+  - `retain_backup_data_on_destroy` - (Optional) - When `true`, destroying the module stops protection and retains the existing recovery points instead of deleting the protected item. Use this for immutable vaults or whenever backup data must outlive the VM. Retained backup data can continue to incur charges. Defaults to `false`.
 
 
 Example Input:
+```hcl
 azure_backup_configurations = {
   arbitrary_key = {
-    recovery_vault_resource_id = azurerm_recovery_services_vault.test_vault.id
-    backup_policy_resource_id    = azurerm_backup_policy_vm.test_policy.id
-    exclude_disk_luns   = [0,1]
+    recovery_vault_resource_id    = azurerm_recovery_services_vault.test_vault.id
+    backup_policy_resource_id     = azurerm_backup_policy_vm.test_policy.id
+    exclude_disk_luns             = [0, 1]
+    retain_backup_data_on_destroy = true
   }
 }
+```
 DESCRIPTION
 }
 


### PR DESCRIPTION
## Description

Fixes the Azure VM backup protected-item lifecycle as one combined problem:

| Issue | Lifecycle phase | Current failure |
|---|---|---|
| #194 | Recreate | A soft-deleted protected item still exists in Azure, so `azapi_resource` refuses creation with `Resource already exists`. |
| #214 | Destroy | `azapi_resource` always sends DELETE, which an immutable vault rejects while active recovery points exist. |
| #163 | Upgrade | The existing `moved` block attempts a cross-provider/type move from `azurerm_backup_protected_vm` to `azapi_resource`. |

The earlier AzureRM implementation has specialized lifecycle handling, but reverting to it would regress #132: AzureRM binds the protected item to the provider subscription, while the current full ARM ID input supports Recovery Services vaults in another subscription.

This PR keeps the AzAPI implementation and models each lifecycle operation explicitly.

### Lifecycle implementation

1. `data.azapi_resource.backup_item` inspects the protected item and tolerates a 404.
2. `azapi_resource_action.backup_ensure_active` performs a PUT:
   - missing, active, or `ProtectionStopped`: sends the full backup configuration to create/resume/adopt the item;
   - soft-deleted: sends `isRehydrate = true` with the required `protectedItemType` discriminator.
3. `azapi_update_resource.backup_protection` manages policy, source VM, and disk inclusion/exclusion properties for drift. Its delete operation is intentionally a no-op.
4. `azapi_resource_action.backup_destroy` explicitly selects the remote destroy operation:
   - default: DELETE, preserving existing behavior;
   - `retain_backup_data_on_destroy = true`: PUTs `ProtectionStopped`, retaining recovery points so an immutable vault does not block VM deletion.

The stop-protection request matches the official Azure Backup `ProtectedItems_CreateOrUpdate` request shape (`protectedItemType`, `protectionState`, and `sourceResourceId`). The rehydrate request matches the payload emitted by the AzureRM provider SDK (`protectedItemType` plus `isRehydrate`).

### State migration

The invalid cross-provider `moved` block is replaced by non-destructive `removed` blocks for both historical addresses:

- `azapi_resource.this_backup_intent`
- `azurerm_backup_protected_vm.this`

Terraform forgets the old state entry without making a remote DELETE request. The new lifecycle then inspects and adopts the existing protected item, so no manual import is required.

### Compatibility

- Cross-subscription Recovery Services vault support is preserved.
- `retain_backup_data_on_destroy` defaults to `false`, so existing deletion behavior and storage-cost semantics do not silently change.
- AzAPI minimum version moves from `2.4` to `2.9`; `ignore_not_found` for `azapi_resource_action` was added in 2.9.
- After recovering a soft-deleted item, a subsequent plan can show a one-time normalization of the bootstrap action body from the rehydrate request to the normal protection request. The protected item is already active and fully managed by `azapi_update_resource` after the first apply.

## Testing

- Added five mocked Terraform test runs covering:
  - fresh protected-item creation;
  - soft-delete detection and rehydration;
  - adoption/resume of active or `ProtectionStopped` items;
  - DELETE versus retain-data (`ProtectionStopped`) destroy behavior;
  - cross-subscription protected-item resource IDs;
  - no resources when backup is unconfigured.
- All root unit tests pass: 16 passed, 0 failed.
- Mutation checks prove the tests fail if either soft-delete detection or retain-on-destroy PUT selection is removed.
- AVM pre-commit and containerized unit tests pass.
- Re-enabled the windows_w_backup E2E example; its vault explicitly disables soft delete, so CI now exercises the real Azure create, reconcile, and default-delete paths.
- AVM PR linting, generated-doc checks, TFLint, module checks, and all example lint checks pass. The local well-architected plans require Azure authentication and are left to CI.

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened bug reports, and this description includes `Closes` references.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

Closes #163
Closes #194
Closes #214


