### PR TITLE
fix: require Terraform 1.10 in submodules for sensitive dynamic for_each

### DIFF
--- a/modules/extension/README.md
+++ b/modules/extension/README.md
@@ -40,7 +40,7 @@ module "avm-res-compute-virtualmachine-extension" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.10, < 2.0)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116, < 5.0)
 

--- a/modules/extension/terraform.tf
+++ b/modules/extension/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.9, < 2.0"
+  required_version = ">= 1.10, < 2.0"
 
   required_providers {
     azurerm = {

--- a/modules/run-command/README.md
+++ b/modules/run-command/README.md
@@ -38,7 +38,7 @@ module "avm-res-compute-virtualmachine-runcommand" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.10, < 2.0)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116, < 5.0)
 

--- a/modules/run-command/terraform.tf
+++ b/modules/run-command/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.9, < 2.0"
+  required_version = ">= 1.10, < 2.0"
 
   required_providers {
     azurerm = {

--- a/tests/unit/run_command_protected_parameters.tftest.hcl
+++ b/tests/unit/run_command_protected_parameters.tftest.hcl
@@ -1,0 +1,51 @@
+# `protected_parameters` is a sensitive map, and the parent module passes `null` for any run command
+# that has no matching `run_commands_secrets` entry (see main.runcommand.tf). Both paths have to
+# iterate cleanly in the `protected_parameter` dynamic block, so the null guard on that `for_each`
+# is load bearing and must not be simplified away.
+mock_provider "azurerm" {}
+
+variables {
+  location                   = "eastus"
+  name                       = "runcmd-test"
+  virtualmachine_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/virtualMachines/vm-test"
+  script_source = {
+    script = "echo hello"
+  }
+}
+
+run "protected_parameters_are_rendered" {
+  command = apply
+
+  module {
+    source = "./modules/run-command"
+  }
+
+  variables {
+    protected_parameters = {
+      p1 = { name = "secret1", value = "value1" }
+      p2 = { name = "secret2", value = "value2" }
+    }
+  }
+
+  assert {
+    condition     = nonsensitive(length(azurerm_virtual_machine_run_command.this.protected_parameter)) == 2
+    error_message = "Both protected parameters should be rendered into the run command."
+  }
+}
+
+run "null_protected_parameters_render_nothing" {
+  command = apply
+
+  module {
+    source = "./modules/run-command"
+  }
+
+  variables {
+    protected_parameters = null
+  }
+
+  assert {
+    condition     = nonsensitive(length(azurerm_virtual_machine_run_command.this.protected_parameter)) == 0
+    error_message = "A null protected_parameters input must produce no protected_parameter blocks."
+  }
+}


### PR DESCRIPTION
## Description

`modules/run-command` failed with a misleading error whenever `protected_parameters` was involved:

```text
Error: Invalid dynamic for_each value

  on modules/run-command/main.tf line 50, in resource "azurerm_virtual_machine_run_command" "this":
  50:     for_each = try(length(var.protected_parameters) > 0, false) ? var.protected_parameters : {}

Cannot use a map of object value in for_each. An iterable collection is required.
```

This is a Terraform core bug, not a module bug. Dynamic block `for_each` did not strip the *sensitive mark* before its iterability check, so a `sensitive = true` map was reported as "not iterable" instead of raising the usual sensitive-value diagnostic. It was fixed in Terraform 1.10.

Reproduced against real binaries with a minimal config mirroring line 50:

| Terraform | Result |
|---|---|
| 1.9.8 | ❌ `Cannot use a map of object value in for_each` |
| 1.10.5 | ✅ passes |
| 1.14.4 | ✅ passes |

This also explains why the error appeared even when nothing was passed in. `length(var.protected_parameters)` derives from a sensitive value, so the *condition* is sensitive, which marks the conditional's result — including the empty `{}` branch. The empty default was verified to fail on 1.9.8 and pass on 1.10.5.

### Changes

The root module already requires `>= 1.10` (bumped in v0.20.0), but `modules/run-command` and `modules/extension` still declared `>= 1.9`. Both are documented, independently consumable submodules, so a standalone consumer on Terraform 1.9.x still hit this with no constraint to warn them. Both are now aligned with the root constraint, which turns a confusing runtime error into a clear "Unsupported Terraform Core version" message.

Adds `tests/unit/run_command_protected_parameters.tftest.hcl` covering both paths through the `protected_parameter` dynamic block.

### Why the `for_each` expression is left alone

A tempting cleanup is to reduce line 50 to `for_each = var.protected_parameters`. That would be a regression. The parent module passes `null` for any run command with no matching `run_commands_secrets` entry:

```hcl
protected_parameters = try(var.run_commands_secrets[each.key].protected_parameters, null)
```

so the `try(length(...) > 0, false)` guard is load bearing. Wrapping the value in `nonsensitive()` was also considered and rejected: it is unnecessary on Terraform >= 1.10, and it strips the mark from the whole map for all downstream use. It only looks safe here because the provider independently marks `protected_parameter` and its `name`/`value` as `Sensitive: true`, which is incidental protection rather than a deliberate guarantee.

## Testing

- `terraform fmt -check -recursive` clean.
- `terraform validate` passes on the root module.
- `terraform test -test-directory=tests/unit` — 19 passed, 0 failed (was 17).
- Mutation check: replacing line 50 with `for_each = var.protected_parameters` makes the new null-path test fail with `Cannot use a null value in for_each`, confirming the test has teeth. Reverted afterwards.
- Submodule READMEs regenerated with the repo's own `terraform-docs` config; the diff is only the version line in each, with no generation churn.
- Container tooling was unavailable locally, so `make pre-commit` was replicated by running the repo's `.terraform-docs.yml` configs directly. The AVM pre-commit checkbox is left unchecked pending a container run.

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

Closes #188
Closes #197
