### PR TITLE
fix: pin VM size in linux_os_managed_disk to avoid NVMe only sizes

### DIFF
--- a/examples/linux_os_managed_disk/README.md
+++ b/examples/linux_os_managed_disk/README.md
@@ -64,6 +64,11 @@ locals {
   tags = {
     scenario = "linux_os_managed_disk"
   }
+  # The OS disk is created from a SCSI only platform image, so the VM size has to support the SCSI
+  # disk controller. avm-utl-sku-finder exposes no disk controller filter and can return NVMe only
+  # sizes such as Standard_L2aos_v4, which fail to boot this disk, so the size is pinned instead of
+  # discovered.
+  vm_sku_size = "Standard_D2s_v3"
 }
 
 resource "random_integer" "region_index" {
@@ -80,24 +85,6 @@ resource "azurerm_resource_group" "this_rg" {
   location = local.deployment_region
   name     = module.naming.resource_group.name_unique
   tags     = local.tags
-}
-
-module "vm_sku" {
-  source  = "Azure/avm-utl-sku-finder/azapi"
-  version = "0.3.0"
-
-  location      = azurerm_resource_group.this_rg.location
-  cache_results = true
-  vm_filters = {
-    min_vcpus                      = 2
-    max_vcpus                      = 2
-    encryption_at_host_supported   = true
-    accelerated_networking_enabled = true
-    premium_io_supported           = true
-    location_zone                  = random_integer.zone_index.result
-  }
-
-  depends_on = [random_integer.zone_index]
 }
 
 module "natgateway" {
@@ -182,7 +169,7 @@ module "testvm" {
   os_disk_attach_mode = true
   os_managed_disk_id  = azurerm_managed_disk.os_disk.id
   os_type             = "Linux"
-  sku_size            = module.vm_sku.sku
+  sku_size            = local.vm_sku_size
   tags                = local.tags
 }
 ```
@@ -262,12 +249,6 @@ Version: 0.5.0
 Source: ../../
 
 Version:
-
-### <a name="module_vm_sku"></a> [vm\_sku](#module\_vm\_sku)
-
-Source: Azure/avm-utl-sku-finder/azapi
-
-Version: 0.3.0
 
 ### <a name="module_vnet"></a> [vnet](#module\_vnet)
 

--- a/examples/linux_os_managed_disk/main.tf
+++ b/examples/linux_os_managed_disk/main.tf
@@ -43,6 +43,11 @@ locals {
   tags = {
     scenario = "linux_os_managed_disk"
   }
+  # The OS disk is created from a SCSI only platform image, so the VM size has to support the SCSI
+  # disk controller. avm-utl-sku-finder exposes no disk controller filter and can return NVMe only
+  # sizes such as Standard_L2aos_v4, which fail to boot this disk, so the size is pinned instead of
+  # discovered.
+  vm_sku_size = "Standard_D2s_v3"
 }
 
 resource "random_integer" "region_index" {
@@ -59,24 +64,6 @@ resource "azurerm_resource_group" "this_rg" {
   location = local.deployment_region
   name     = module.naming.resource_group.name_unique
   tags     = local.tags
-}
-
-module "vm_sku" {
-  source  = "Azure/avm-utl-sku-finder/azapi"
-  version = "0.3.0"
-
-  location      = azurerm_resource_group.this_rg.location
-  cache_results = true
-  vm_filters = {
-    min_vcpus                      = 2
-    max_vcpus                      = 2
-    encryption_at_host_supported   = true
-    accelerated_networking_enabled = true
-    premium_io_supported           = true
-    location_zone                  = random_integer.zone_index.result
-  }
-
-  depends_on = [random_integer.zone_index]
 }
 
 module "natgateway" {
@@ -161,6 +148,6 @@ module "testvm" {
   os_disk_attach_mode = true
   os_managed_disk_id  = azurerm_managed_disk.os_disk.id
   os_type             = "Linux"
-  sku_size            = module.vm_sku.sku
+  sku_size            = local.vm_sku_size
   tags                = local.tags
 }


### PR DESCRIPTION
## Description

`examples/linux_os_managed_disk` fails intermittently on unrelated pull requests.

`avm-utl-sku-finder` selects a size at random from its filtered list and exposes no disk controller filter, so it can return an NVMe only size such as `Standard_L2aos_v4`. The OS disk in this example is created from a SCSI only Ubuntu 20.04 gen2 platform image, so those sizes fail the apply:

```text
Error: creating Linux Virtual Machine (...): performing CreateOrUpdate: unexpected status 400 (400 Bad Request)
with error: InvalidParameter: The VM size 'Standard_L2aos_v4' cannot boot with OS image or disk. Please check
that disk controller types supported by the OS image or disk is one of the supported disk controller types for
the VM size 'Standard_L2aos_v4'.
```

Whether the example passes therefore depends on which size is drawn. It has been passing by luck.

This was surfaced by the E2E run on #371, where a new example copied these same `vm_filters` and drew an NVMe only size. The `vm_filters` block here is identical, so this example carries the same latent failure.

### Changes

Pins the VM size and drops the now unused `avm-utl-sku-finder` module. The size is incidental to what this example demonstrates — attaching an existing managed disk as the OS disk — so discovering it adds flakiness without adding value.

`Standard_D2s_v3` supports the SCSI disk controller, Gen2 images, premium storage, and all three `canadacentral` availability zones, which covers everything the previous filters were asking for.

### Alternatives considered

- **Filtering the finder** — `vm_filters` has no disk controller option, so NVMe only families cannot be excluded.
- **Selecting from `sku_list`** — would require matching on size family names, which is brittle.
- **Making the image NVMe capable** — would mean switching the seed image and marking the gallery image as NVMe supported. That claim cannot be verified without a live apply, and getting it wrong produces a VM that provisions but may not boot, which is a worse failure mode than a loud one.

## Testing

- `terraform fmt -check -recursive` clean.
- `terraform validate` passes on the example.
- Example README regenerated with the repo's `terraform-docs` config; the diff is limited to the removed module and the embedded `main.tf`.
- No references to `module.vm_sku` remain in the example.
- Container tooling was unavailable locally, so `make pre-commit` was replicated by running the repo's `.terraform-docs.yml` configs directly. The AVM pre-commit checkbox is left unchecked pending a container run.

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [x] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks
