### PR TITLE
fix: validate Microsoft Entra SSH extension prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -686,6 +686,8 @@ Description: This map of objects is used to create additional `azurerm_virtual_m
   - `tags` (Optional) - A mapping of tags to assign to the extension resource.
   - `timeouts` (Optional): Timeouts for the extension resource.
 
+> Note: AzureRM versions 4.25 through 4.30 could return `MismatchingNestedResourceSegments` when updating the identity of a Linux VM that already had extensions installed. This provider regression was fixed in AzureRM 4.31 by [hashicorp/terraform-provider-azurerm#29717](https://github.com/hashicorp/terraform-provider-azurerm/pull/29717). This module requires AzureRM 4.42 or later and therefore includes the fix.
+
 Example Inputs:
 
 ```hcl

--- a/README.md
+++ b/README.md
@@ -689,6 +689,20 @@ Description: This map of objects is used to create additional `azurerm_virtual_m
 Example Inputs:
 
 ```hcl
+# Microsoft Entra SSH login extension for Linux
+managed_identities = {
+  system_assigned = true
+}
+extensions = {
+  aad_ssh_login = {
+    name                       = "AADSSHLoginForLinux"
+    publisher                  = "Microsoft.Azure.ActiveDirectory"
+    type                       = "AADSSHLoginForLinux"
+    type_handler_version       = "1.0"
+    auto_upgrade_minor_version = true
+  }
+}
+
 #custom script extension example - linux
 extensions = {
   custom_script_extension_linux = {
@@ -898,7 +912,7 @@ Default: `{}`
 
 ### <a name="input_managed_identities"></a> [managed\_identities](#input\_managed\_identities)
 
-Description: An object that sets the managed identity configuration for the virtual machine being deployed. Be aware that capabilities such as the Azure Monitor Agent and Role Assignments require that a managed identity has been configured.
+Description: An object that sets the managed identity configuration for the virtual machine being deployed. Be aware that capabilities such as the Azure Monitor Agent and Role Assignments require that a managed identity has been configured. The `AADSSHLoginForLinux` extension requires `system_assigned = true`.
 
 - `system_assigned`            = (Optional) Specifies whether the System Assigned Managed Identity should be enabled.  Defaults to false.
 - `user_assigned_resource_ids` = (Optional) Specifies a set of User Assigned Managed Identity IDs to be assigned to this Virtual Machine.

--- a/tests/unit/aad_ssh_login_extension.tftest.hcl
+++ b/tests/unit/aad_ssh_login_extension.tftest.hcl
@@ -1,0 +1,135 @@
+mock_provider "azapi" {}
+mock_provider "azurerm" {
+  mock_resource "azurerm_network_interface" {
+    defaults = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/networkInterfaces/nic-test"
+    }
+  }
+
+  mock_resource "azurerm_linux_virtual_machine" {
+    defaults = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/virtualMachines/vm-aad-ssh"
+      os_disk = {
+        id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/disks/vm-aad-ssh-osdisk"
+      }
+    }
+  }
+
+  mock_resource "azurerm_virtual_machine_extension" {
+    defaults = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/virtualMachines/vm-aad-ssh/extensions/AADSSHLoginForLinux"
+    }
+  }
+}
+mock_provider "modtm" {}
+mock_provider "random" {
+  mock_resource "random_password" {
+    defaults = {
+      result = "avmUnitTest123!"
+    }
+  }
+}
+mock_provider "tls" {}
+
+variables {
+  location            = "eastus"
+  name                = "vm-aad-ssh"
+  resource_group_name = "rg-test"
+  zone                = "1"
+  os_type             = "Linux"
+  account_credentials = {
+    admin_credentials = {
+      generate_admin_password_or_ssh_key = true
+    }
+    password_authentication_disabled = false
+  }
+  extensions = {
+    aad_ssh_login = {
+      name                       = "AADSSHLoginForLinux"
+      publisher                  = "Microsoft.Azure.ActiveDirectory"
+      type                       = "AADSSHLoginForLinux"
+      type_handler_version       = "1.0"
+      auto_upgrade_minor_version = true
+    }
+  }
+  network_interfaces = {
+    network_interface_1 = {
+      name = "nic-test"
+      ip_configurations = {
+        ip_configuration_1 = {
+          name                          = "nic-test-ipconfig1"
+          private_ip_subnet_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-test/subnets/snet-test"
+        }
+      }
+    }
+  }
+  source_image_reference = {
+    publisher = "Canonical"
+    offer     = "ubuntu-24_04-lts"
+    sku       = "server"
+    version   = "latest"
+  }
+}
+
+run "aad_ssh_login_requires_system_assigned_identity" {
+  command = plan
+
+  expect_failures = [var.extensions]
+}
+
+run "aad_ssh_login_requires_linux" {
+  command = plan
+
+  variables {
+    os_type = "Windows"
+    account_credentials = {
+      admin_credentials = {
+        generate_admin_password_or_ssh_key = true
+      }
+    }
+    managed_identities = {
+      system_assigned = true
+    }
+    source_image_reference = {
+      publisher = "MicrosoftWindowsServer"
+      offer     = "WindowsServer"
+      sku       = "2022-datacenter-g2"
+      version   = "latest"
+    }
+  }
+
+  expect_failures = [var.extensions]
+}
+
+run "aad_ssh_login_requires_vm_agent_and_extension_operations" {
+  command = plan
+
+  variables {
+    allow_extension_operations = false
+    provision_vm_agent         = false
+    managed_identities = {
+      system_assigned = true
+    }
+  }
+
+  expect_failures = [var.extensions]
+}
+
+run "aad_ssh_login_with_required_prerequisites" {
+  command = apply
+
+  variables {
+    managed_identities = {
+      system_assigned = true
+    }
+  }
+
+  assert {
+    condition     = azurerm_linux_virtual_machine.this[0].identity[0].type == "SystemAssigned"
+    error_message = "The valid AAD SSH configuration must enable the VM's system-assigned managed identity."
+  }
+  assert {
+    condition     = module.extension["aad_ssh_login"].resource_id == "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/virtualMachines/vm-aad-ssh/extensions/AADSSHLoginForLinux"
+    error_message = "The AADSSHLoginForLinux extension must be created when all prerequisites are configured."
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -599,6 +599,20 @@ This map of objects is used to create additional `azurerm_virtual_machine_extens
 Example Inputs:
 
 ```hcl
+# Microsoft Entra SSH login extension for Linux
+managed_identities = {
+  system_assigned = true
+}
+extensions = {
+  aad_ssh_login = {
+    name                       = "AADSSHLoginForLinux"
+    publisher                  = "Microsoft.Azure.ActiveDirectory"
+    type                       = "AADSSHLoginForLinux"
+    type_handler_version       = "1.0"
+    auto_upgrade_minor_version = true
+  }
+}
+
 #custom script extension example - linux
 extensions = {
   custom_script_extension_linux = {
@@ -649,6 +663,19 @@ EXTENSIONS
       for e in var.extensions : e.type
     ]))
     error_message = "`type` in `vm_extensions` must be unique."
+  }
+
+  validation {
+    condition = !anytrue([
+      for extension in nonsensitive(var.extensions) :
+      lower(extension.type) == "aadsshloginforlinux"
+      ]) || (
+      lower(var.os_type) == "linux" &&
+      var.managed_identities.system_assigned &&
+      var.provision_vm_agent &&
+      var.allow_extension_operations
+    )
+    error_message = "AADSSHLoginForLinux requires os_type = \"Linux\", managed_identities.system_assigned = true, provision_vm_agent = true, and allow_extension_operations = true."
   }
 }
 
@@ -750,7 +777,7 @@ variable "managed_identities" {
   })
   default     = {}
   description = <<IDENTITY
-An object that sets the managed identity configuration for the virtual machine being deployed. Be aware that capabilities such as the Azure Monitor Agent and Role Assignments require that a managed identity has been configured.
+An object that sets the managed identity configuration for the virtual machine being deployed. Be aware that capabilities such as the Azure Monitor Agent and Role Assignments require that a managed identity has been configured. The `AADSSHLoginForLinux` extension requires `system_assigned = true`.
 
 - `system_assigned`            = (Optional) Specifies whether the System Assigned Managed Identity should be enabled.  Defaults to false.
 - `user_assigned_resource_ids` = (Optional) Specifies a set of User Assigned Managed Identity IDs to be assigned to this Virtual Machine.

--- a/variables.tf
+++ b/variables.tf
@@ -596,6 +596,8 @@ This map of objects is used to create additional `azurerm_virtual_machine_extens
   - `tags` (Optional) - A mapping of tags to assign to the extension resource.
   - `timeouts` (Optional): Timeouts for the extension resource.
 
+> Note: AzureRM versions 4.25 through 4.30 could return `MismatchingNestedResourceSegments` when updating the identity of a Linux VM that already had extensions installed. This provider regression was fixed in AzureRM 4.31 by [hashicorp/terraform-provider-azurerm#29717](https://github.com/hashicorp/terraform-provider-azurerm/pull/29717). This module requires AzureRM 4.42 or later and therefore includes the fix.
+
 Example Inputs:
 
 ```hcl
@@ -664,7 +666,6 @@ EXTENSIONS
     ]))
     error_message = "`type` in `vm_extensions` must be unique."
   }
-
   validation {
     condition = !anytrue([
       for extension in nonsensitive(var.extensions) :


### PR DESCRIPTION
## Description

Issue #173 reported `MismatchingNestedResourceSegments` while configuring `AADSSHLoginForLinux`. There were two separate concerns:

1. **AzureRM provider regression:** identity updates on Linux VMs included installed extensions as nested resources. The linked provider PR #29336 was closed in favor of [hashicorp/terraform-provider-azurerm#29717](https://github.com/hashicorp/terraform-provider-azurerm/pull/29717), which shipped in AzureRM **4.31.0**. This module already requires AzureRM **>= 4.42**, so current consumers receive the provider fix.
2. **Invalid AAD SSH prerequisites:** the issue configuration omitted the required extension `name` and did not enable a system-assigned managed identity. `name` is already required by the input type, but the remaining prerequisites were only discovered after Azure attempted extension installation.

This PR adds plan-time validation when an extension has `type = "AADSSHLoginForLinux"`. The VM must:

- use `os_type = "Linux"`;
- enable `managed_identities.system_assigned`;
- keep `provision_vm_agent` enabled;
- keep `allow_extension_operations` enabled.

These requirements match the Microsoft Entra SSH documentation. Password authentication is intentionally not validated because Microsoft does not list disabling local password authentication as an extension-installation prerequisite.

### Documentation

The `extensions` input now includes a complete `AADSSHLoginForLinux` example with the required extension `name` and system-assigned identity. The managed identity documentation also calls out the requirement.

## Testing

Added `tests/unit/aad_ssh_login_extension.tftest.hcl` covering:

- rejection without a system-assigned identity;
- rejection on a Windows VM;
- rejection when the VM agent and extension operations are disabled;
- successful VM identity and extension creation with all prerequisites.

The AVM pre-commit and full containerized unit test suite pass. The clean-tree PR checker was attempted locally; provider/plugin downloads were interrupted by Docker DNS and concurrent TFLint plugin extraction failures, so the full check is left to CI.

A module unit test cannot reproduce the segment-length provider regression because mocked providers bypass AzureRM request serialization. The upstream provider fix includes its own regression tests, and the module's AzureRM version floor guarantees that fix.

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and this description includes a `Closes` reference.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

Closes #173
