### PR TITLE
docs: explain why os_disk and network interfaces have no delete_option

### DIFF
--- a/README.md
+++ b/README.md
@@ -986,6 +986,8 @@ Description: A map of objects representing each network virtual machine network 
       - `principal_type`                             = (Optional) - The type of the `principal_id`. Possible values are `User`, `Group` and `ServicePrincipal`. It is necessary to explicitly set this attribute when creating role assignments if the principal creating the assignment is constrained by ABAC rules that filters on the PrincipalType attribute.
   - `tags`                           = (Optional) - A mapping of tags to assign to the resource.
 
+> Note: There is no per network interface `delete_option` input because the `azurerm` provider does not expose `networkProfile.networkInterfaces[].deleteOption`; `network_interface_ids` on the virtual machine resource is a plain list of IDs. This module creates each network interface as its own `azurerm_network_interface` resource, so `terraform destroy` deletes them along with the virtual machine and they are not orphaned. That setting only affects deletions performed outside Terraform.
+
 Example Inputs:
 
 ```hcl
@@ -1137,6 +1139,8 @@ Description: Required configuration values for the OS disk on the virtual machin
 
 > Note: The `azurerm` provider's `os_disk` block does not expose the disk network access settings, so `public_network_access_enabled`, `network_access_policy`, and `disk_access_resource_id` are applied to the OS Disk with an `azapi_update_resource` after the virtual machine has been created. Removing these values from the configuration later removes the update resource from state but does not revert the settings on the disk in Azure - set them back to their previous values explicitly instead.
 
+> Note: There is no `delete_option` input because the `azurerm` provider does not expose `storageProfile.osDisk.deleteOption` on `azurerm_linux_virtual_machine` or `azurerm_windows_virtual_machine`. The OS Disk is created implicitly by the virtual machine resource, so it is not tracked separately in state and Azure leaves it behind when the virtual machine is deleted. Deleting it with the virtual machine is controlled by the `delete_os_disk_on_deletion` setting in the provider `features` block rather than by this module, and that setting defaults to `false`. Data disks, network interfaces, and public IP addresses are managed as their own resources by this module and are destroyed normally, so they are not affected by it.
+
 Example Inputs:
 
 ```hcl
@@ -1177,6 +1181,16 @@ os_disk = {
   caching              = "ReadWrite"
   storage_account_type = "Premium_LRS"
   lock_level           = "CanNotDelete"
+}
+
+#delete the os disk when the virtual machine is destroyed. This is a provider
+#level setting rather than an os_disk value, and it defaults to false.
+provider "azurerm" {
+  features {
+    virtual_machine {
+      delete_os_disk_on_deletion = true
+    }
+  }
 }
 ```
 

--- a/variables.tf
+++ b/variables.tf
@@ -926,6 +926,8 @@ A map of objects representing each network virtual machine network interface
       - `principal_type`                             = (Optional) - The type of the `principal_id`. Possible values are `User`, `Group` and `ServicePrincipal`. It is necessary to explicitly set this attribute when creating role assignments if the principal creating the assignment is constrained by ABAC rules that filters on the PrincipalType attribute.
   - `tags`                           = (Optional) - A mapping of tags to assign to the resource.
 
+> Note: There is no per network interface `delete_option` input because the `azurerm` provider does not expose `networkProfile.networkInterfaces[].deleteOption`; `network_interface_ids` on the virtual machine resource is a plain list of IDs. This module creates each network interface as its own `azurerm_network_interface` resource, so `terraform destroy` deletes them along with the virtual machine and they are not orphaned. That setting only affects deletions performed outside Terraform.
+
 Example Inputs:
 
 ```hcl
@@ -1007,6 +1009,8 @@ Required configuration values for the OS disk on the virtual machine.
 
 > Note: The `azurerm` provider's `os_disk` block does not expose the disk network access settings, so `public_network_access_enabled`, `network_access_policy`, and `disk_access_resource_id` are applied to the OS Disk with an `azapi_update_resource` after the virtual machine has been created. Removing these values from the configuration later removes the update resource from state but does not revert the settings on the disk in Azure - set them back to their previous values explicitly instead.
 
+> Note: There is no `delete_option` input because the `azurerm` provider does not expose `storageProfile.osDisk.deleteOption` on `azurerm_linux_virtual_machine` or `azurerm_windows_virtual_machine`. The OS Disk is created implicitly by the virtual machine resource, so it is not tracked separately in state and Azure leaves it behind when the virtual machine is deleted. Deleting it with the virtual machine is controlled by the `delete_os_disk_on_deletion` setting in the provider `features` block rather than by this module, and that setting defaults to `false`. Data disks, network interfaces, and public IP addresses are managed as their own resources by this module and are destroyed normally, so they are not affected by it.
+
 Example Inputs:
 
 ```hcl
@@ -1047,6 +1051,16 @@ os_disk = {
   caching              = "ReadWrite"
   storage_account_type = "Premium_LRS"
   lock_level           = "CanNotDelete"
+}
+
+#delete the os disk when the virtual machine is destroyed. This is a provider
+#level setting rather than an os_disk value, and it defaults to false.
+provider "azurerm" {
+  features {
+    virtual_machine {
+      delete_os_disk_on_deletion = true
+    }
+  }
 }
 ```
 OS_DISK


### PR DESCRIPTION
## Description

#246 asks for a `delete_option` input on `os_disk` and per network interface, on the basis that both are "configurable in the underlying `azurerm_windows_virtual_machine` resource". They are not.

`delete_option` does not exist anywhere in the `azurerm` provider's compute service:

- `virtualMachineOSDiskSchema()` in `internal/services/compute/virtual_machine.go` defines `caching`, `storage_account_type`, `diff_disk_settings`, `disk_encryption_set_id`, `disk_size_gb`, `name`, `secure_vm_disk_encryption_set_id`, `security_encryption_type`, `write_accelerator_enabled`, and `id` — there is no `delete_option`.
- `network_interface_ids` is a flat `TypeList` of strings, so there is no per interface block to attach an option to.
- Neither `storageProfile.osDisk.deleteOption` nor `networkProfile.networkInterfaces[].deleteOption` is referenced in the provider, and neither appears in the provider documentation.

Adding `delete_option = var.os_disk.delete_option` to the `os_disk` block would therefore fail with `Unsupported argument`. This PR documents what actually controls the behavior instead.

### OS disk

This is the real half of the request. The OS disk is created implicitly by the virtual machine resource, so it is not tracked separately in state and Azure leaves it behind when the virtual machine is deleted.

The provider handles this with a provider level feature flag rather than a resource argument (`windows_virtual_machine_resource.go:1816` reads `Features.VirtualMachine.DeleteOSDiskOnDeletion` and issues a separate disk delete after deleting the VM):

```hcl
provider "azurerm" {
  features {
    virtual_machine {
      delete_os_disk_on_deletion = true
    }
  }
}
```

This defaults to `false`. It is consumer side configuration, so an AVM module cannot set it — modules do not declare provider blocks.

### Network interfaces

The reported orphaning does not apply here. This module creates each network interface as its own `azurerm_network_interface` resource (`main.networking.tf:22`), so `terraform destroy` deletes them along with the virtual machine. The same is true of data disks and public IP addresses. `deleteOption` on a NIC only matters when the virtual machine is deleted outside Terraform.

### Changes

Adds a note to the `os_disk` description explaining why there is no `delete_option` and what controls OS disk deletion, with the provider snippet added to the existing `Example Inputs` block, plus a note to `network_interfaces` explaining why interfaces are not orphaned. Regenerates the root README.

An upstream feature request already exists for each half, so no new issue was filed:

- [hashicorp/terraform-provider-azurerm#11518](https://github.com/hashicorp/terraform-provider-azurerm/issues/11518) — per resource OS disk deletion instead of the provider global flag (open since April 2021)
- [hashicorp/terraform-provider-azurerm#25105](https://github.com/hashicorp/terraform-provider-azurerm/issues/25105) — `networkInterfaceConfigurations`, which is what carries the per NIC `deleteOption` (open since February 2024)

If either lands, this module can surface the input and the corresponding note can be replaced.

## Testing

- `terraform fmt -check -recursive` clean.
- `terraform validate` passes.
- `terraform test -test-directory=tests/unit` — 17 passed, 0 failed.
- README regenerated with the repo's `terraform-docs` config. The first draft nested a fenced code block inside a blockquote, which terraform-docs rendered with a broken closing fence; the snippet was moved into the existing `Example Inputs` block and the generated output was re-checked.
- Container tooling was unavailable locally, so `make pre-commit` was replicated by running the repo's `.terraform-docs.yml` config directly. The AVM pre-commit checkbox is left unchecked pending a container run.

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

Closes #246
