### PR TITLE
feat: declare the TFFR6/7/8 AzAPI interface variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -920,6 +920,34 @@ Type: `bool`
 
 Default: `false`
 
+### <a name="input_ignore_body_changes"></a> [ignore\_body\_changes](#input\_ignore\_body\_changes)
+
+Description: Body-relative paths whose changes the AzAPI provider ignores, per resource. Paths use dot notation,  
+for example `properties.maintenanceConfigurationId`. Individual list items cannot be targeted;  
+ignore the whole list property instead.
+
+Configuration changes at an ignored path are not sent to Azure until that path is removed from the  
+list. Because the value is held in provider-private state, a change takes effect only after an  
+apply.
+
+- `maintenance_configuration_assignments` - Ignored body paths for the maintenance configuration assignments.
+- `recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems` - Paths passed to the backup submodule.
+- `recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems.recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems` - Ignored body paths for the backup protected item.
+
+Type:
+
+```hcl
+object({
+    maintenance_configuration_assignments = optional(list(string), [])
+
+    recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems = optional(object({
+      recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems = optional(list(string), [])
+    }), {})
+  })
+```
+
+Default: `{}`
+
 ### <a name="input_license_type"></a> [license\_type](#input\_license\_type)
 
 Description: (Optional) For Linux virtual machine specifies the BYOL Type for this Virtual Machine, possible values are `RHEL_BYOS` and `SLES_BYOS`. For Windows virtual machine specifies the type of on-premise license (also known as [Azure Hybrid Use Benefit](https://docs.microsoft.com/windows-server/get-started/azure-hybrid-benefit)) which should be used for this Virtual Machine, possible values are `None`, `Windows_Client` and `Windows_Server`.
@@ -1516,6 +1544,55 @@ Type: `string`
 
 Default: `null`
 
+### <a name="input_resource_types"></a> [resource\_types](#input\_resource\_types)
+
+Description: Override the AzAPI `<provider>/<resource>@<api-version>` strings used by this module. Each key  
+defaults to a tested value; supply only the keys you want to override. Useful when targeting a  
+sovereign cloud with older API versions, or when opting into a newer preview API.
+
+- `maintenance_configuration_assignments` - Maintenance configuration assignments applied to the virtual machine.
+- `compute_disks` - The managed disk type used when updating the OS disk network access settings.
+- `recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems` - Resource-type overrides passed to the backup submodule.
+- `recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems.recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems` - The backup protected item.
+
+Type:
+
+```hcl
+object({
+    maintenance_configuration_assignments = optional(string, "Microsoft.Maintenance/configurationAssignments@2023-04-01")
+    compute_disks                         = optional(string, "Microsoft.Compute/disks@2024-03-02")
+
+    recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems = optional(object({
+      recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems = optional(string)
+    }), {})
+  })
+```
+
+Default: `{}`
+
+### <a name="input_retry"></a> [retry](#input\_retry)
+
+Description: Retry configuration applied to every AzAPI resource managed by the module and its submodules.  
+Defaults to `null` (no custom retry).
+
+- `error_message_regex` - (Optional) A list of regex patterns matching error messages that trigger a retry.
+- `interval_seconds` - (Optional) Initial interval between retries in seconds.
+- `max_interval_seconds` - (Optional) Maximum interval between retries in seconds.
+
+See <https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource#retry> for full semantics.
+
+Type:
+
+```hcl
+object({
+    error_message_regex  = optional(list(string))
+    interval_seconds     = optional(number)
+    max_interval_seconds = optional(number)
+  })
+```
+
+Default: `null`
+
 ### <a name="input_role_assignments"></a> [role\_assignments](#input\_role\_assignments)
 
 Description: A map of role definitions and scopes to be assigned as part of this resources implementation.  Two forms are supported. Assignments against this virtual machine resource scope and assignments to external resource scopes using the system managed identity.
@@ -1927,36 +2004,61 @@ Default: `null`
 
 ### <a name="input_timeouts"></a> [timeouts](#input\_timeouts)
 
-Description: A map of timeouts to apply to the creation and destruction of resources.  
-If using retry, the maximum elapsed retry time is governed by this value.
+Description: Default per-operation timeouts applied to every AzAPI resource managed by the module and its  
+submodules, and used as the fallback for the extension and run command resources. Defaults to
+`null` (provider defaults). Each value is a Go duration string, for example `30m` or `1h`.
 
-The object has attributes for each resource type, with the following optional attributes:
+Extensions and run commands resolve their timeouts in this order: the per-item `timeouts` on the  
+individual `extensions` or `run_commands` entry, then the deprecated
+`timeouts_by_resource_type` input, then this variable.
 
-- `create` - (Optional) The timeout for creating the resource.
-- `delete` - (Optional) The timeout for deleting the resource.
-- `update` - (Optional) The timeout for updating the resource.
-- `read` - (Optional) The timeout for reading the resource.
+- `create` - (Optional) Timeout for create operations.
+- `read` - (Optional) Timeout for read operations.
+- `update` - (Optional) Timeout for update operations.
+- `delete` - (Optional) Timeout for delete operations.
 
-Each time duration is parsed using this function: <https://pkg.go.dev/time#ParseDuration>.
+Type:
+
+```hcl
+object({
+    create = optional(string)
+    read   = optional(string)
+    update = optional(string)
+    delete = optional(string)
+  })
+```
+
+Default: `null`
+
+### <a name="input_timeouts_by_resource_type"></a> [timeouts\_by\_resource\_type](#input\_timeouts\_by\_resource\_type)
+
+Description: DEPRECATED: This input carries the per-resource-type timeouts that `timeouts` used to hold. The
+`timeouts` input now takes the flat AVM shape required by TFFR7, which applies to every AzAPI  
+resource in the module, so the per-resource-type form moved here. This input will be removed with  
+the release of version v1.0.0; prefer the per-item `timeouts` on an individual `extensions` or
+`run_commands` entry, or the module-wide `timeouts` input.
+
+Values here take precedence over `timeouts` and are overridden by a per-item `timeouts`.
+
+- `azurerm_virtual_machine_extension` - Timeouts applied to virtual machine extensions.
+- `azurerm_virtual_machine_run_command` - Timeouts applied to virtual machine run commands.
 
 Type:
 
 ```hcl
 object({
     azurerm_virtual_machine_extension = optional(object({
-      create = optional(string, "30m")
-      delete = optional(string, "30m")
-      update = optional(string, "30m")
-      read   = optional(string, "5m")
-      }), {}
-    )
+      create = optional(string)
+      delete = optional(string)
+      update = optional(string)
+      read   = optional(string)
+    }), {})
     azurerm_virtual_machine_run_command = optional(object({
-      create = optional(string, "30m")
-      delete = optional(string, "30m")
-      update = optional(string, "30m")
-      read   = optional(string, "5m")
-      }), {}
-    )
+      create = optional(string)
+      delete = optional(string)
+      update = optional(string)
+      read   = optional(string)
+    }), {})
   })
 ```
 

--- a/deprecated_variables.tf
+++ b/deprecated_variables.tf
@@ -91,3 +91,34 @@ For simplicity this module provides the option to use an auto-generated admin us
 - `tags` - (Optional) - Specific tags to assign to this secret resource
 DESCRIPTION
 }
+
+variable "timeouts_by_resource_type" {
+  type = object({
+    azurerm_virtual_machine_extension = optional(object({
+      create = optional(string)
+      delete = optional(string)
+      update = optional(string)
+      read   = optional(string)
+    }), {})
+    azurerm_virtual_machine_run_command = optional(object({
+      create = optional(string)
+      delete = optional(string)
+      update = optional(string)
+      read   = optional(string)
+    }), {})
+  })
+  default     = {}
+  description = <<DESCRIPTION
+DEPRECATED: This input carries the per-resource-type timeouts that `timeouts` used to hold. The
+`timeouts` input now takes the flat AVM shape required by TFFR7, which applies to every AzAPI
+resource in the module, so the per-resource-type form moved here. This input will be removed with
+the release of version v1.0.0; prefer the per-item `timeouts` on an individual `extensions` or
+`run_commands` entry, or the module-wide `timeouts` input.
+
+Values here take precedence over `timeouts` and are overridden by a per-item `timeouts`.
+
+- `azurerm_virtual_machine_extension` - Timeouts applied to virtual machine extensions.
+- `azurerm_virtual_machine_run_command` - Timeouts applied to virtual machine run commands.
+DESCRIPTION
+  nullable    = false
+}

--- a/main.backup.tf
+++ b/main.backup.tf
@@ -9,8 +9,12 @@ module "backup" {
   backup_policy_resource_id     = each.value.backup_policy_resource_id
   enable_telemetry              = var.enable_telemetry
   exclude_disk_luns             = each.value.exclude_disk_luns
+  ignore_body_changes           = var.ignore_body_changes.recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems
   include_disk_luns             = each.value.include_disk_luns
+  resource_types                = var.resource_types.recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems
   retain_backup_data_on_destroy = each.value.retain_backup_data_on_destroy
+  retry                         = var.retry
+  timeouts                      = var.timeouts
 
   depends_on = [
     azurerm_virtual_machine_data_disk_attachment.this_linux,

--- a/main.extensions.tf
+++ b/main.extensions.tf
@@ -17,10 +17,10 @@ module "extension" {
   settings                          = var.extensions[each.key].settings
   tags                              = var.extensions[each.key].tags != null && var.extensions[each.key].tags != {} ? var.extensions[each.key].tags : local.tags
   timeouts = {
-    create = coalesce(try(var.extensions[each.key].timeouts.create, null), var.timeouts.azurerm_virtual_machine_extension.create)
-    delete = coalesce(try(var.extensions[each.key].timeouts.delete, null), var.timeouts.azurerm_virtual_machine_extension.delete)
-    read   = coalesce(try(var.extensions[each.key].timeouts.read, null), var.timeouts.azurerm_virtual_machine_extension.read)
-    update = coalesce(try(var.extensions[each.key].timeouts.update, null), var.timeouts.azurerm_virtual_machine_extension.update)
+    create = coalesce(try(var.extensions[each.key].timeouts.create, null), var.timeouts_by_resource_type.azurerm_virtual_machine_extension.create, try(var.timeouts.create, null), "30m")
+    delete = coalesce(try(var.extensions[each.key].timeouts.delete, null), var.timeouts_by_resource_type.azurerm_virtual_machine_extension.delete, try(var.timeouts.delete, null), "30m")
+    read   = coalesce(try(var.extensions[each.key].timeouts.read, null), var.timeouts_by_resource_type.azurerm_virtual_machine_extension.read, try(var.timeouts.read, null), "5m")
+    update = coalesce(try(var.extensions[each.key].timeouts.update, null), var.timeouts_by_resource_type.azurerm_virtual_machine_extension.update, try(var.timeouts.update, null), "30m")
   }
 
   depends_on = [
@@ -52,10 +52,10 @@ module "extension_1" {
   settings                          = var.extensions[each.key].settings
   tags                              = var.extensions[each.key].tags != null && var.extensions[each.key].tags != {} ? var.extensions[each.key].tags : local.tags
   timeouts = {
-    create = coalesce(try(var.extensions[each.key].timeouts.create, null), var.timeouts.azurerm_virtual_machine_extension.create)
-    delete = coalesce(try(var.extensions[each.key].timeouts.delete, null), var.timeouts.azurerm_virtual_machine_extension.delete)
-    read   = coalesce(try(var.extensions[each.key].timeouts.read, null), var.timeouts.azurerm_virtual_machine_extension.read)
-    update = coalesce(try(var.extensions[each.key].timeouts.update, null), var.timeouts.azurerm_virtual_machine_extension.update)
+    create = coalesce(try(var.extensions[each.key].timeouts.create, null), var.timeouts_by_resource_type.azurerm_virtual_machine_extension.create, try(var.timeouts.create, null), "30m")
+    delete = coalesce(try(var.extensions[each.key].timeouts.delete, null), var.timeouts_by_resource_type.azurerm_virtual_machine_extension.delete, try(var.timeouts.delete, null), "30m")
+    read   = coalesce(try(var.extensions[each.key].timeouts.read, null), var.timeouts_by_resource_type.azurerm_virtual_machine_extension.read, try(var.timeouts.read, null), "5m")
+    update = coalesce(try(var.extensions[each.key].timeouts.update, null), var.timeouts_by_resource_type.azurerm_virtual_machine_extension.update, try(var.timeouts.update, null), "30m")
   }
 
   depends_on = [
@@ -83,10 +83,10 @@ module "extension_2" {
   settings                          = var.extensions[each.key].settings
   tags                              = var.extensions[each.key].tags != null && var.extensions[each.key].tags != {} ? var.extensions[each.key].tags : local.tags
   timeouts = {
-    create = coalesce(try(var.extensions[each.key].timeouts.create, null), var.timeouts.azurerm_virtual_machine_extension.create)
-    delete = coalesce(try(var.extensions[each.key].timeouts.delete, null), var.timeouts.azurerm_virtual_machine_extension.delete)
-    read   = coalesce(try(var.extensions[each.key].timeouts.read, null), var.timeouts.azurerm_virtual_machine_extension.read)
-    update = coalesce(try(var.extensions[each.key].timeouts.update, null), var.timeouts.azurerm_virtual_machine_extension.update)
+    create = coalesce(try(var.extensions[each.key].timeouts.create, null), var.timeouts_by_resource_type.azurerm_virtual_machine_extension.create, try(var.timeouts.create, null), "30m")
+    delete = coalesce(try(var.extensions[each.key].timeouts.delete, null), var.timeouts_by_resource_type.azurerm_virtual_machine_extension.delete, try(var.timeouts.delete, null), "30m")
+    read   = coalesce(try(var.extensions[each.key].timeouts.read, null), var.timeouts_by_resource_type.azurerm_virtual_machine_extension.read, try(var.timeouts.read, null), "5m")
+    update = coalesce(try(var.extensions[each.key].timeouts.update, null), var.timeouts_by_resource_type.azurerm_virtual_machine_extension.update, try(var.timeouts.update, null), "30m")
   }
 
   depends_on = [
@@ -115,10 +115,10 @@ module "extension_3" {
   settings                          = var.extensions[each.key].settings
   tags                              = var.extensions[each.key].tags != null && var.extensions[each.key].tags != {} ? var.extensions[each.key].tags : local.tags
   timeouts = {
-    create = coalesce(try(var.extensions[each.key].timeouts.create, null), var.timeouts.azurerm_virtual_machine_extension.create)
-    delete = coalesce(try(var.extensions[each.key].timeouts.delete, null), var.timeouts.azurerm_virtual_machine_extension.delete)
-    read   = coalesce(try(var.extensions[each.key].timeouts.read, null), var.timeouts.azurerm_virtual_machine_extension.read)
-    update = coalesce(try(var.extensions[each.key].timeouts.update, null), var.timeouts.azurerm_virtual_machine_extension.update)
+    create = coalesce(try(var.extensions[each.key].timeouts.create, null), var.timeouts_by_resource_type.azurerm_virtual_machine_extension.create, try(var.timeouts.create, null), "30m")
+    delete = coalesce(try(var.extensions[each.key].timeouts.delete, null), var.timeouts_by_resource_type.azurerm_virtual_machine_extension.delete, try(var.timeouts.delete, null), "30m")
+    read   = coalesce(try(var.extensions[each.key].timeouts.read, null), var.timeouts_by_resource_type.azurerm_virtual_machine_extension.read, try(var.timeouts.read, null), "5m")
+    update = coalesce(try(var.extensions[each.key].timeouts.update, null), var.timeouts_by_resource_type.azurerm_virtual_machine_extension.update, try(var.timeouts.update, null), "30m")
   }
 
   depends_on = [
@@ -148,10 +148,10 @@ module "extension_4" {
   settings                          = var.extensions[each.key].settings
   tags                              = var.extensions[each.key].tags != null && var.extensions[each.key].tags != {} ? var.extensions[each.key].tags : local.tags
   timeouts = {
-    create = coalesce(try(var.extensions[each.key].timeouts.create, null), var.timeouts.azurerm_virtual_machine_extension.create)
-    delete = coalesce(try(var.extensions[each.key].timeouts.delete, null), var.timeouts.azurerm_virtual_machine_extension.delete)
-    read   = coalesce(try(var.extensions[each.key].timeouts.read, null), var.timeouts.azurerm_virtual_machine_extension.read)
-    update = coalesce(try(var.extensions[each.key].timeouts.update, null), var.timeouts.azurerm_virtual_machine_extension.update)
+    create = coalesce(try(var.extensions[each.key].timeouts.create, null), var.timeouts_by_resource_type.azurerm_virtual_machine_extension.create, try(var.timeouts.create, null), "30m")
+    delete = coalesce(try(var.extensions[each.key].timeouts.delete, null), var.timeouts_by_resource_type.azurerm_virtual_machine_extension.delete, try(var.timeouts.delete, null), "30m")
+    read   = coalesce(try(var.extensions[each.key].timeouts.read, null), var.timeouts_by_resource_type.azurerm_virtual_machine_extension.read, try(var.timeouts.read, null), "5m")
+    update = coalesce(try(var.extensions[each.key].timeouts.update, null), var.timeouts_by_resource_type.azurerm_virtual_machine_extension.update, try(var.timeouts.update, null), "30m")
   }
 
   depends_on = [

--- a/main.maintenance_configurations.tf
+++ b/main.maintenance_configurations.tf
@@ -19,16 +19,29 @@ resource "azapi_resource" "this_maintenance_configuration_assignment" {
   location  = var.location
   name      = "${var.name}-maintenance-configuration-${each.key}"
   parent_id = local.virtualmachine_resource_id
-  type      = "Microsoft.Maintenance/configurationAssignments@2023-04-01"
+  type      = var.resource_types.maintenance_configuration_assignments
   body = {
     properties = {
       maintenanceConfigurationId = lower(each.value)
     }
   }
-  create_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
-  delete_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
-  read_headers   = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
-  update_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  create_headers      = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  delete_headers      = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_body_changes = length(var.ignore_body_changes.maintenance_configuration_assignments) > 0 ? var.ignore_body_changes.maintenance_configuration_assignments : null
+  read_headers        = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  retry               = var.retry
+  update_headers      = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 }
 
 moved {

--- a/main.os_disk.tf
+++ b/main.os_disk.tf
@@ -26,11 +26,23 @@ resource "azapi_update_resource" "this_os_disk_network_access" {
   count = local.os_disk_network_access_configured ? 1 : 0
 
   resource_id            = local.os_disk_resource_id
-  type                   = "Microsoft.Compute/disks@2024-03-02"
+  type                   = var.resource_types.compute_disks
   body                   = local.os_disk_network_access_body
   read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   response_export_values = ["properties.publicNetworkAccess", "properties.networkAccessPolicy", "properties.diskAccessId"]
+  retry                  = var.retry
   update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 
   depends_on = [
     azurerm_virtual_machine_data_disk_attachment.this_linux,

--- a/main.runcommand.tf
+++ b/main.runcommand.tf
@@ -16,10 +16,10 @@ module "run_command" {
   run_as_user                  = try(var.run_commands_secrets[each.key].run_as_user, null)
   tags                         = each.value.tags
   timeouts = {
-    create = coalesce(try(each.value.timeouts.create, null), var.timeouts.azurerm_virtual_machine_run_command.create)
-    delete = coalesce(try(each.value.timeouts.delete, null), var.timeouts.azurerm_virtual_machine_run_command.delete)
-    read   = coalesce(try(each.value.timeouts.read, null), var.timeouts.azurerm_virtual_machine_run_command.read)
-    update = coalesce(try(each.value.timeouts.update, null), var.timeouts.azurerm_virtual_machine_run_command.update)
+    create = coalesce(try(each.value.timeouts.create, null), var.timeouts_by_resource_type.azurerm_virtual_machine_run_command.create, try(var.timeouts.create, null), "30m")
+    delete = coalesce(try(each.value.timeouts.delete, null), var.timeouts_by_resource_type.azurerm_virtual_machine_run_command.delete, try(var.timeouts.delete, null), "30m")
+    read   = coalesce(try(each.value.timeouts.read, null), var.timeouts_by_resource_type.azurerm_virtual_machine_run_command.read, try(var.timeouts.read, null), "5m")
+    update = coalesce(try(each.value.timeouts.update, null), var.timeouts_by_resource_type.azurerm_virtual_machine_run_command.update, try(var.timeouts.update, null), "30m")
   }
 
   depends_on = [
@@ -51,10 +51,10 @@ module "run_command_1" {
   run_as_user                  = try(var.run_commands_secrets[each.key].run_as_user, null)
   tags                         = each.value.tags
   timeouts = {
-    create = coalesce(try(each.value.timeouts.create, null), var.timeouts.azurerm_virtual_machine_run_command.create)
-    delete = coalesce(try(each.value.timeouts.delete, null), var.timeouts.azurerm_virtual_machine_run_command.delete)
-    read   = coalesce(try(each.value.timeouts.read, null), var.timeouts.azurerm_virtual_machine_run_command.read)
-    update = coalesce(try(each.value.timeouts.update, null), var.timeouts.azurerm_virtual_machine_run_command.update)
+    create = coalesce(try(each.value.timeouts.create, null), var.timeouts_by_resource_type.azurerm_virtual_machine_run_command.create, try(var.timeouts.create, null), "30m")
+    delete = coalesce(try(each.value.timeouts.delete, null), var.timeouts_by_resource_type.azurerm_virtual_machine_run_command.delete, try(var.timeouts.delete, null), "30m")
+    read   = coalesce(try(each.value.timeouts.read, null), var.timeouts_by_resource_type.azurerm_virtual_machine_run_command.read, try(var.timeouts.read, null), "5m")
+    update = coalesce(try(each.value.timeouts.update, null), var.timeouts_by_resource_type.azurerm_virtual_machine_run_command.update, try(var.timeouts.update, null), "30m")
   }
 
   depends_on = [
@@ -84,10 +84,10 @@ module "run_command_2" {
   run_as_user                  = try(var.run_commands_secrets[each.key].run_as_user, null)
   tags                         = each.value.tags
   timeouts = {
-    create = coalesce(try(each.value.timeouts.create, null), var.timeouts.azurerm_virtual_machine_run_command.create)
-    delete = coalesce(try(each.value.timeouts.delete, null), var.timeouts.azurerm_virtual_machine_run_command.delete)
-    read   = coalesce(try(each.value.timeouts.read, null), var.timeouts.azurerm_virtual_machine_run_command.read)
-    update = coalesce(try(each.value.timeouts.update, null), var.timeouts.azurerm_virtual_machine_run_command.update)
+    create = coalesce(try(each.value.timeouts.create, null), var.timeouts_by_resource_type.azurerm_virtual_machine_run_command.create, try(var.timeouts.create, null), "30m")
+    delete = coalesce(try(each.value.timeouts.delete, null), var.timeouts_by_resource_type.azurerm_virtual_machine_run_command.delete, try(var.timeouts.delete, null), "30m")
+    read   = coalesce(try(each.value.timeouts.read, null), var.timeouts_by_resource_type.azurerm_virtual_machine_run_command.read, try(var.timeouts.read, null), "5m")
+    update = coalesce(try(each.value.timeouts.update, null), var.timeouts_by_resource_type.azurerm_virtual_machine_run_command.update, try(var.timeouts.update, null), "30m")
   }
 
   depends_on = [

--- a/modules/backup/README.md
+++ b/modules/backup/README.md
@@ -124,6 +124,28 @@ Type: `list(number)`
 
 Default: `null`
 
+### <a name="input_ignore_body_changes"></a> [ignore\_body\_changes](#input\_ignore\_body\_changes)
+
+Description: Body-relative paths whose changes the AzAPI provider ignores, per resource. Paths use dot notation.  
+Configuration changes at an ignored path are not sent to Azure until that path is removed from the  
+list, and a change takes effect only after an apply.
+
+This submodule manages the protected item through `azapi_resource_action` and
+`azapi_update_resource`, neither of which supports `ignore_body_changes`, so the variable is  
+declared for interface consistency but is not currently applied to a resource.
+
+- `recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems` - Ignored body paths for the backup protected item.
+
+Type:
+
+```hcl
+object({
+    recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems = optional(list(string), [])
+  })
+```
+
+Default: `{}`
+
 ### <a name="input_include_disk_luns"></a> [include\_disk\_luns](#input\_include\_disk\_luns)
 
 Description: `include_disk_luns` - (Optional) - A list of Disk Logical Unit Numbers (LUN) to be included for VM Protection. Only one of `exclude_disk_luns` or `include_disk_luns` can be set. If both are set then only the `exclude_disk_luns` value will be used.
@@ -132,6 +154,23 @@ Type: `list(number)`
 
 Default: `null`
 
+### <a name="input_resource_types"></a> [resource\_types](#input\_resource\_types)
+
+Description: Override the AzAPI `<provider>/<resource>@<api-version>` strings used by this module. Each key  
+defaults to a tested value; supply only the keys you want to override.
+
+- `recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems` - The backup protected item.
+
+Type:
+
+```hcl
+object({
+    recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems = optional(string, "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems@2024-10-01")
+  })
+```
+
+Default: `{}`
+
 ### <a name="input_retain_backup_data_on_destroy"></a> [retain\_backup\_data\_on\_destroy](#input\_retain\_backup\_data\_on\_destroy)
 
 Description: `retain_backup_data_on_destroy` - (Optional) - When `true`, destroying the module stops protection and retains the existing recovery points instead of deleting the protected item. Use this for immutable vaults or whenever backup data must outlive the VM. Retained backup data can continue to incur charges. Defaults to `false`.
@@ -139,6 +178,50 @@ Description: `retain_backup_data_on_destroy` - (Optional) - When `true`, destroy
 Type: `bool`
 
 Default: `false`
+
+### <a name="input_retry"></a> [retry](#input\_retry)
+
+Description: Retry configuration applied to every AzAPI resource managed by the module. Defaults to `null` (no  
+custom retry).
+
+- `error_message_regex` - (Optional) A list of regex patterns matching error messages that trigger a retry.
+- `interval_seconds` - (Optional) Initial interval between retries in seconds.
+- `max_interval_seconds` - (Optional) Maximum interval between retries in seconds.
+
+Type:
+
+```hcl
+object({
+    error_message_regex  = optional(list(string))
+    interval_seconds     = optional(number)
+    max_interval_seconds = optional(number)
+  })
+```
+
+Default: `null`
+
+### <a name="input_timeouts"></a> [timeouts](#input\_timeouts)
+
+Description: Default per-operation timeouts applied to every AzAPI resource managed by the module. Defaults to
+`null` (provider defaults). Each value is a Go duration string, for example `30m` or `1h`.
+
+- `create` - (Optional) Timeout for create operations.
+- `read` - (Optional) Timeout for read operations.
+- `update` - (Optional) Timeout for update operations.
+- `delete` - (Optional) Timeout for delete operations.
+
+Type:
+
+```hcl
+object({
+    create = optional(string)
+    read   = optional(string)
+    update = optional(string)
+    delete = optional(string)
+  })
+```
+
+Default: `null`
 
 ## Outputs
 

--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -2,7 +2,7 @@ locals {
   # The protection container and protected item names are derived from the virtual machine's
   # resource group and name. The recovery services vault may live in another subscription.
   backup_container_name               = "iaasvmcontainerv2;${var.resource_group_name};${var.virtual_machine_name}"
-  backup_protected_item_resource_type = "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems@2024-10-01"
+  backup_protected_item_resource_type = var.resource_types.recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems
   backup_item_resource_id             = "${var.recovery_vault_resource_id}/backupFabrics/Azure/protectionContainers/iaasvmcontainer;${local.backup_container_name}/protectedItems/VM;${local.backup_container_name}"
   backup_body_extended_properties = try(length(var.exclude_disk_luns) > 0, false) ? {
     extendedProperties = {
@@ -56,6 +56,18 @@ resource "azapi_resource_action" "backup_ensure_active" {
   locks                  = [local.backup_item_resource_id]
   response_export_values = []
   when                   = "apply"
+  retry                  = var.retry
+
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 }
 
 # Manage the declared backup properties after the create/resume/rehydrate operation. Unlike
@@ -74,6 +86,18 @@ resource "azapi_update_resource" "backup_protection" {
   update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
 
   depends_on = [azapi_resource_action.backup_ensure_active]
+  retry      = var.retry
+
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 }
 
 # The Backup API uses PUT ProtectionStopped to retain recovery points and DELETE to remove them.
@@ -96,4 +120,16 @@ resource "azapi_resource_action" "backup_destroy" {
   when                   = "destroy"
 
   depends_on = [azapi_update_resource.backup_protection]
+  retry      = var.retry
+
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
 }

--- a/modules/backup/variables.tf
+++ b/modules/backup/variables.tf
@@ -73,3 +73,73 @@ variable "retain_backup_data_on_destroy" {
 DESCRIPTION
   nullable    = false
 }
+
+# tflint-ignore: terraform_unused_declarations
+variable "ignore_body_changes" {
+  type = object({
+    recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems = optional(list(string), [])
+  })
+  default     = {}
+  nullable    = false
+  description = <<DESCRIPTION
+Body-relative paths whose changes the AzAPI provider ignores, per resource. Paths use dot notation.
+Configuration changes at an ignored path are not sent to Azure until that path is removed from the
+list, and a change takes effect only after an apply.
+
+This submodule manages the protected item through `azapi_resource_action` and
+`azapi_update_resource`, neither of which supports `ignore_body_changes`, so the variable is
+declared for interface consistency but is not currently applied to a resource.
+
+- `recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems` - Ignored body paths for the backup protected item.
+DESCRIPTION
+}
+
+variable "resource_types" {
+  type = object({
+    recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems = optional(string, "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems@2024-10-01")
+  })
+  default     = {}
+  nullable    = false
+  description = <<DESCRIPTION
+Override the AzAPI `<provider>/<resource>@<api-version>` strings used by this module. Each key
+defaults to a tested value; supply only the keys you want to override.
+
+- `recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems` - The backup protected item.
+DESCRIPTION
+}
+
+variable "retry" {
+  type = object({
+    error_message_regex  = optional(list(string))
+    interval_seconds     = optional(number)
+    max_interval_seconds = optional(number)
+  })
+  default     = null
+  description = <<DESCRIPTION
+Retry configuration applied to every AzAPI resource managed by the module. Defaults to `null` (no
+custom retry).
+
+- `error_message_regex` - (Optional) A list of regex patterns matching error messages that trigger a retry.
+- `interval_seconds` - (Optional) Initial interval between retries in seconds.
+- `max_interval_seconds` - (Optional) Maximum interval between retries in seconds.
+DESCRIPTION
+}
+
+variable "timeouts" {
+  type = object({
+    create = optional(string)
+    read   = optional(string)
+    update = optional(string)
+    delete = optional(string)
+  })
+  default     = null
+  description = <<DESCRIPTION
+Default per-operation timeouts applied to every AzAPI resource managed by the module. Defaults to
+`null` (provider defaults). Each value is a Go duration string, for example `30m` or `1h`.
+
+- `create` - (Optional) Timeout for create operations.
+- `read` - (Optional) Timeout for read operations.
+- `update` - (Optional) Timeout for update operations.
+- `delete` - (Optional) Timeout for delete operations.
+DESCRIPTION
+}

--- a/variables.tf
+++ b/variables.tf
@@ -723,6 +723,31 @@ variable "hotpatching_enabled" {
   description = "(Optional) Should the VM be patched without requiring a reboot? Possible values are `true` or `false`. Defaults to `false`. For more information about hot patching please see the [product documentation](https://docs.microsoft.com/azure/automanage/automanage-hotpatch). Hotpatching can only be enabled if the `patch_mode` is set to `AutomaticByPlatform`, the `provision_vm_agent` is set to `true`, your `source_image_reference` references a hotpatching enabled image, and the VM's `size` is set to a [Azure generation 2](https://docs.microsoft.com/azure/virtual-machines/generation-2#generation-2-vm-sizes) VM. An example of how to correctly configure a Windows Virtual Machine to use the `hotpatching_enabled` field can be found in the [`./examples/virtual-machines/windows/hotpatching-enabled`](https://github.com/hashicorp/terraform-provider-azurerm/tree/main/examples/virtual-machines/windows/hotpatching-enabled) directory within the GitHub Repository."
 }
 
+variable "ignore_body_changes" {
+  type = object({
+    maintenance_configuration_assignments = optional(list(string), [])
+
+    recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems = optional(object({
+      recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems = optional(list(string), [])
+    }), {})
+  })
+  default     = {}
+  description = <<DESCRIPTION
+Body-relative paths whose changes the AzAPI provider ignores, per resource. Paths use dot notation,
+for example `properties.maintenanceConfigurationId`. Individual list items cannot be targeted;
+ignore the whole list property instead.
+
+Configuration changes at an ignored path are not sent to Azure until that path is removed from the
+list. Because the value is held in provider-private state, a change takes effect only after an
+apply.
+
+- `maintenance_configuration_assignments` - Ignored body paths for the maintenance configuration assignments.
+- `recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems` - Paths passed to the backup submodule.
+- `recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems.recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems` - Ignored body paths for the backup protected item.
+DESCRIPTION
+  nullable    = false
+}
+
 variable "license_type" {
   type        = string
   default     = null
@@ -1306,6 +1331,48 @@ variable "reboot_setting" {
   description = "(Optional) Specifies the reboot setting for platform scheduled patching. Possible values are Always, IfRequired and Never. can only be set when patch_mode is set to AutomaticByPlatform"
 }
 
+variable "resource_types" {
+  type = object({
+    maintenance_configuration_assignments = optional(string, "Microsoft.Maintenance/configurationAssignments@2023-04-01")
+    compute_disks                         = optional(string, "Microsoft.Compute/disks@2024-03-02")
+
+    recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems = optional(object({
+      recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems = optional(string)
+    }), {})
+  })
+  default     = {}
+  description = <<DESCRIPTION
+Override the AzAPI `<provider>/<resource>@<api-version>` strings used by this module. Each key
+defaults to a tested value; supply only the keys you want to override. Useful when targeting a
+sovereign cloud with older API versions, or when opting into a newer preview API.
+
+- `maintenance_configuration_assignments` - Maintenance configuration assignments applied to the virtual machine.
+- `compute_disks` - The managed disk type used when updating the OS disk network access settings.
+- `recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems` - Resource-type overrides passed to the backup submodule.
+- `recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems.recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems` - The backup protected item.
+DESCRIPTION
+  nullable    = false
+}
+
+variable "retry" {
+  type = object({
+    error_message_regex  = optional(list(string))
+    interval_seconds     = optional(number)
+    max_interval_seconds = optional(number)
+  })
+  default     = null
+  description = <<DESCRIPTION
+Retry configuration applied to every AzAPI resource managed by the module and its submodules.
+Defaults to `null` (no custom retry).
+
+- `error_message_regex` - (Optional) A list of regex patterns matching error messages that trigger a retry.
+- `interval_seconds` - (Optional) Initial interval between retries in seconds.
+- `max_interval_seconds` - (Optional) Maximum interval between retries in seconds.
+
+See <https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource#retry> for full semantics.
+DESCRIPTION
+}
+
 variable "role_assignments" {
   type = map(object({
     role_definition_id_or_name             = string
@@ -1683,34 +1750,25 @@ TERMINATION_NOTIFICATION
 
 variable "timeouts" {
   type = object({
-    azurerm_virtual_machine_extension = optional(object({
-      create = optional(string, "30m")
-      delete = optional(string, "30m")
-      update = optional(string, "30m")
-      read   = optional(string, "5m")
-      }), {}
-    )
-    azurerm_virtual_machine_run_command = optional(object({
-      create = optional(string, "30m")
-      delete = optional(string, "30m")
-      update = optional(string, "30m")
-      read   = optional(string, "5m")
-      }), {}
-    )
+    create = optional(string)
+    read   = optional(string)
+    update = optional(string)
+    delete = optional(string)
   })
-  default     = {}
+  default     = null
   description = <<DESCRIPTION
-A map of timeouts to apply to the creation and destruction of resources.
-If using retry, the maximum elapsed retry time is governed by this value.
+Default per-operation timeouts applied to every AzAPI resource managed by the module and its
+submodules, and used as the fallback for the extension and run command resources. Defaults to
+`null` (provider defaults). Each value is a Go duration string, for example `30m` or `1h`.
 
-The object has attributes for each resource type, with the following optional attributes:
+Extensions and run commands resolve their timeouts in this order: the per-item `timeouts` on the
+individual `extensions` or `run_commands` entry, then the deprecated
+`timeouts_by_resource_type` input, then this variable.
 
-- `create` - (Optional) The timeout for creating the resource.
-- `delete` - (Optional) The timeout for deleting the resource.
-- `update` - (Optional) The timeout for updating the resource.
-- `read` - (Optional) The timeout for reading the resource.
-
-Each time duration is parsed using this function: <https://pkg.go.dev/time#ParseDuration>.
+- `create` - (Optional) Timeout for create operations.
+- `read` - (Optional) Timeout for read operations.
+- `update` - (Optional) Timeout for update operations.
+- `delete` - (Optional) Timeout for delete operations.
 DESCRIPTION
 }
 


### PR DESCRIPTION
## Description

The managed lint ruleset now enforces [TFFR6](https://azure.github.io/Azure-Verified-Modules/spec/TFFR6/), [TFFR7](https://azure.github.io/Azure-Verified-Modules/spec/TFFR7/) and [TFFR8](https://azure.github.io/Azure-Verified-Modules/spec/TFFR8/) on every scope that *directly* declares an AzAPI resource. The root module and the backup submodule both do, so `avm lint` fails on `main` today with five errors.

This declares the four required interface variables — `resource_types`, `retry`, `timeouts` and `ignore_body_changes` — in both scopes, and wires them into every AzAPI resource that accepts them.

| Scope | AzAPI resources wired |
|---|---|
| root | `azapi_resource.this_maintenance_configuration_assignment`, `azapi_update_resource.this_os_disk_network_access` |
| `modules/backup` | `azapi_resource_action.backup_ensure_active`, `azapi_update_resource.backup_protection`, `azapi_resource_action.backup_destroy` |

## Trade-offs

**1. `timeouts` changes shape — this is the breaking part.**

TFFR7 mandates the flat `{create, read, update, delete}` object applied to every AzAPI resource. The existing per-resource-type form is incompatible, so it moves to a new deprecated `timeouts_by_resource_type` input (removed in v1.0.0). Consumers setting `timeouts` today must rename to `timeouts_by_resource_type`, or adopt the flat shape.

Effective behaviour is unchanged for anyone who sets neither. Extensions and run commands resolve in order: per-item `timeouts` → `timeouts_by_resource_type` → `timeouts` → the same `30m`/`5m` defaults as before.

**2. `ignore_body_changes` is declared but unused in the backup submodule.**

TFFR8 lists `azapi_resource_action` and `azapi_update_resource` as triggering types, but the provider only implements the argument on `azapi_resource` — verified against the azapi 2.12.0 schema and the [current provider docs](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/update_resource). The backup submodule declares only the former two, so there is nothing to apply it to.

The variable is declared for interface conformance and carries `# tflint-ignore: terraform_unused_declarations`, matching the existing precedent in `main.telemetry.tf`. The variable description states plainly that it is not currently applied. The alternative — omitting it — fails TFFR8 as a hard error.

## Test results

| Check | Result |
|---|---|
| `avm lint` | **pass** (was 5 errors) |
| `avm pre-commit` | **pass**, READMEs regenerated |
| `avm test unit` | **31 runs, 31 passed, 0 failed** |

Two `deprecated_lock_interface` / `deprecated_role_assignments_interface` notices remain. They are pre-existing, non-blocking, and out of scope here.

No e2e run: this adds optional variables that all default to `null`/`{}`, so every example plans and applies exactly as before.

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [x] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

> [!NOTE]
> #387 is currently red for exactly this lint failure. It will be updated on top of this once merged, adding the `ignore_body_changes` keys for the AzAPI resources it introduces.
