### PR TITLE
fix: use # comments so tflint terraform_comment_syntax passes

### DIFF
--- a/examples/linux_default/README.md
+++ b/examples/linux_default/README.md
@@ -147,27 +147,26 @@ module "vnet" {
   }
 }
 
-/* Uncomment this section if you would like to include a bastion resource with this example.
-resource "azurerm_public_ip" "bastionpip" {
-  name                = module.naming.public_ip.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-  allocation_method   = "Static"
-  sku                 = "Standard"
-}
-
-resource "azurerm_bastion_host" "bastion" {
-  name                = module.naming.bastion_host.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-
-  ip_configuration {
-    name                 = "${module.naming.bastion_host.name_unique}-ipconf"
-    subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
-    public_ip_address_id = azurerm_public_ip.bastionpip.id
-  }
-}
-*/
+# Uncomment this section if you would like to include a bastion resource with this example.
+# resource "azurerm_public_ip" "bastionpip" {
+#   name                = module.naming.public_ip.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#   allocation_method   = "Static"
+#   sku                 = "Standard"
+# }
+#
+# resource "azurerm_bastion_host" "bastion" {
+#   name                = module.naming.bastion_host.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#
+#   ip_configuration {
+#     name                 = "${module.naming.bastion_host.name_unique}-ipconf"
+#     subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
+#     public_ip_address_id = azurerm_public_ip.bastionpip.id
+#   }
+# }
 
 data "azurerm_client_config" "current" {}
 

--- a/examples/linux_default/main.tf
+++ b/examples/linux_default/main.tf
@@ -128,27 +128,26 @@ module "vnet" {
   }
 }
 
-/* Uncomment this section if you would like to include a bastion resource with this example.
-resource "azurerm_public_ip" "bastionpip" {
-  name                = module.naming.public_ip.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-  allocation_method   = "Static"
-  sku                 = "Standard"
-}
-
-resource "azurerm_bastion_host" "bastion" {
-  name                = module.naming.bastion_host.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-
-  ip_configuration {
-    name                 = "${module.naming.bastion_host.name_unique}-ipconf"
-    subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
-    public_ip_address_id = azurerm_public_ip.bastionpip.id
-  }
-}
-*/
+# Uncomment this section if you would like to include a bastion resource with this example.
+# resource "azurerm_public_ip" "bastionpip" {
+#   name                = module.naming.public_ip.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#   allocation_method   = "Static"
+#   sku                 = "Standard"
+# }
+#
+# resource "azurerm_bastion_host" "bastion" {
+#   name                = module.naming.bastion_host.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#
+#   ip_configuration {
+#     name                 = "${module.naming.bastion_host.name_unique}-ipconf"
+#     subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
+#     public_ip_address_id = azurerm_public_ip.bastionpip.id
+#   }
+# }
 
 data "azurerm_client_config" "current" {}
 

--- a/examples/linux_ubuntu_w_ssh_auth/README.md
+++ b/examples/linux_ubuntu_w_ssh_auth/README.md
@@ -161,27 +161,26 @@ resource "azurerm_resource_group" "this_rg_secondary" {
   tags     = local.tags
 }
 
-/* #uncomment these resources to enable bastion
-resource "azurerm_public_ip" "bastionpip" {
-  allocation_method   = "Static"
-  location            = azurerm_resource_group.this_rg.location
-  name                = module.naming.public_ip.name_unique
-  resource_group_name = azurerm_resource_group.this_rg.name
-  sku                 = "Standard"
-}
-
-resource "azurerm_bastion_host" "bastion" {
-  location            = azurerm_resource_group.this_rg.location
-  name                = module.naming.bastion_host.name_unique
-  resource_group_name = azurerm_resource_group.this_rg.name
-
-  ip_configuration {
-    name                 = "${module.naming.bastion_host.name_unique}-ipconf"
-    public_ip_address_id = azurerm_public_ip.bastionpip.id
-    subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
-  }
-}
-*/
+# #uncomment these resources to enable bastion
+# resource "azurerm_public_ip" "bastionpip" {
+#   allocation_method   = "Static"
+#   location            = azurerm_resource_group.this_rg.location
+#   name                = module.naming.public_ip.name_unique
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#   sku                 = "Standard"
+# }
+#
+# resource "azurerm_bastion_host" "bastion" {
+#   location            = azurerm_resource_group.this_rg.location
+#   name                = module.naming.bastion_host.name_unique
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#
+#   ip_configuration {
+#     name                 = "${module.naming.bastion_host.name_unique}-ipconf"
+#     public_ip_address_id = azurerm_public_ip.bastionpip.id
+#     subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
+#   }
+# }
 
 data "azurerm_client_config" "current" {}
 

--- a/examples/linux_ubuntu_w_ssh_auth/main.tf
+++ b/examples/linux_ubuntu_w_ssh_auth/main.tf
@@ -138,27 +138,26 @@ resource "azurerm_resource_group" "this_rg_secondary" {
   tags     = local.tags
 }
 
-/* #uncomment these resources to enable bastion
-resource "azurerm_public_ip" "bastionpip" {
-  allocation_method   = "Static"
-  location            = azurerm_resource_group.this_rg.location
-  name                = module.naming.public_ip.name_unique
-  resource_group_name = azurerm_resource_group.this_rg.name
-  sku                 = "Standard"
-}
-
-resource "azurerm_bastion_host" "bastion" {
-  location            = azurerm_resource_group.this_rg.location
-  name                = module.naming.bastion_host.name_unique
-  resource_group_name = azurerm_resource_group.this_rg.name
-
-  ip_configuration {
-    name                 = "${module.naming.bastion_host.name_unique}-ipconf"
-    public_ip_address_id = azurerm_public_ip.bastionpip.id
-    subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
-  }
-}
-*/
+# #uncomment these resources to enable bastion
+# resource "azurerm_public_ip" "bastionpip" {
+#   allocation_method   = "Static"
+#   location            = azurerm_resource_group.this_rg.location
+#   name                = module.naming.public_ip.name_unique
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#   sku                 = "Standard"
+# }
+#
+# resource "azurerm_bastion_host" "bastion" {
+#   location            = azurerm_resource_group.this_rg.location
+#   name                = module.naming.bastion_host.name_unique
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#
+#   ip_configuration {
+#     name                 = "${module.naming.bastion_host.name_unique}-ipconf"
+#     public_ip_address_id = azurerm_public_ip.bastionpip.id
+#     subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
+#   }
+# }
 
 data "azurerm_client_config" "current" {}
 

--- a/examples/linux_ubuntu_with_autogen_password/README.md
+++ b/examples/linux_ubuntu_with_autogen_password/README.md
@@ -148,27 +148,26 @@ module "vnet" {
   }
 }
 
-/* #uncomment these resources to enable bastion
-resource "azurerm_public_ip" "bastionpip" {
-  allocation_method   = "Static"
-  location            = azurerm_resource_group.this_rg.location
-  name                = module.naming.public_ip.name_unique
-  resource_group_name = azurerm_resource_group.this_rg.name
-  sku                 = "Standard"
-}
-
-resource "azurerm_bastion_host" "bastion" {
-  location            = azurerm_resource_group.this_rg.location
-  name                = module.naming.bastion_host.name_unique
-  resource_group_name = azurerm_resource_group.this_rg.name
-
-  ip_configuration {
-    name                 = "${module.naming.bastion_host.name_unique}-ipconf"
-    public_ip_address_id = azurerm_public_ip.bastionpip.id
-    subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
-  }
-}
-*/
+# #uncomment these resources to enable bastion
+# resource "azurerm_public_ip" "bastionpip" {
+#   allocation_method   = "Static"
+#   location            = azurerm_resource_group.this_rg.location
+#   name                = module.naming.public_ip.name_unique
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#   sku                 = "Standard"
+# }
+#
+# resource "azurerm_bastion_host" "bastion" {
+#   location            = azurerm_resource_group.this_rg.location
+#   name                = module.naming.bastion_host.name_unique
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#
+#   ip_configuration {
+#     name                 = "${module.naming.bastion_host.name_unique}-ipconf"
+#     public_ip_address_id = azurerm_public_ip.bastionpip.id
+#     subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
+#   }
+# }
 
 data "azurerm_client_config" "current" {}
 

--- a/examples/linux_ubuntu_with_autogen_password/main.tf
+++ b/examples/linux_ubuntu_with_autogen_password/main.tf
@@ -127,27 +127,26 @@ module "vnet" {
   }
 }
 
-/* #uncomment these resources to enable bastion
-resource "azurerm_public_ip" "bastionpip" {
-  allocation_method   = "Static"
-  location            = azurerm_resource_group.this_rg.location
-  name                = module.naming.public_ip.name_unique
-  resource_group_name = azurerm_resource_group.this_rg.name
-  sku                 = "Standard"
-}
-
-resource "azurerm_bastion_host" "bastion" {
-  location            = azurerm_resource_group.this_rg.location
-  name                = module.naming.bastion_host.name_unique
-  resource_group_name = azurerm_resource_group.this_rg.name
-
-  ip_configuration {
-    name                 = "${module.naming.bastion_host.name_unique}-ipconf"
-    public_ip_address_id = azurerm_public_ip.bastionpip.id
-    subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
-  }
-}
-*/
+# #uncomment these resources to enable bastion
+# resource "azurerm_public_ip" "bastionpip" {
+#   allocation_method   = "Static"
+#   location            = azurerm_resource_group.this_rg.location
+#   name                = module.naming.public_ip.name_unique
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#   sku                 = "Standard"
+# }
+#
+# resource "azurerm_bastion_host" "bastion" {
+#   location            = azurerm_resource_group.this_rg.location
+#   name                = module.naming.bastion_host.name_unique
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#
+#   ip_configuration {
+#     name                 = "${module.naming.bastion_host.name_unique}-ipconf"
+#     public_ip_address_id = azurerm_public_ip.bastionpip.id
+#     subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
+#   }
+# }
 
 data "azurerm_client_config" "current" {}
 

--- a/examples/linux_ubuntu_with_plaintext_password/README.md
+++ b/examples/linux_ubuntu_with_plaintext_password/README.md
@@ -148,27 +148,26 @@ module "vnet" {
   }
 }
 
-/* Uncomment this section if you would like to include a bastion resource with this example.
-resource "azurerm_public_ip" "bastionpip" {
-  name                = module.naming.public_ip.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-  allocation_method   = "Static"
-  sku                 = "Standard"
-}
-
-resource "azurerm_bastion_host" "bastion" {
-  name                = module.naming.bastion_host.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-
-  ip_configuration {
-    name                 = "${module.naming.bastion_host.name_unique}-ipconf"
-    subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
-    public_ip_address_id = azurerm_public_ip.bastionpip.id
-  }
-}
-*/
+# Uncomment this section if you would like to include a bastion resource with this example.
+# resource "azurerm_public_ip" "bastionpip" {
+#   name                = module.naming.public_ip.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#   allocation_method   = "Static"
+#   sku                 = "Standard"
+# }
+#
+# resource "azurerm_bastion_host" "bastion" {
+#   name                = module.naming.bastion_host.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#
+#   ip_configuration {
+#     name                 = "${module.naming.bastion_host.name_unique}-ipconf"
+#     subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
+#     public_ip_address_id = azurerm_public_ip.bastionpip.id
+#   }
+# }
 
 data "azurerm_client_config" "current" {}
 

--- a/examples/linux_ubuntu_with_plaintext_password/main.tf
+++ b/examples/linux_ubuntu_with_plaintext_password/main.tf
@@ -127,27 +127,26 @@ module "vnet" {
   }
 }
 
-/* Uncomment this section if you would like to include a bastion resource with this example.
-resource "azurerm_public_ip" "bastionpip" {
-  name                = module.naming.public_ip.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-  allocation_method   = "Static"
-  sku                 = "Standard"
-}
-
-resource "azurerm_bastion_host" "bastion" {
-  name                = module.naming.bastion_host.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-
-  ip_configuration {
-    name                 = "${module.naming.bastion_host.name_unique}-ipconf"
-    subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
-    public_ip_address_id = azurerm_public_ip.bastionpip.id
-  }
-}
-*/
+# Uncomment this section if you would like to include a bastion resource with this example.
+# resource "azurerm_public_ip" "bastionpip" {
+#   name                = module.naming.public_ip.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#   allocation_method   = "Static"
+#   sku                 = "Standard"
+# }
+#
+# resource "azurerm_bastion_host" "bastion" {
+#   name                = module.naming.bastion_host.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#
+#   ip_configuration {
+#     name                 = "${module.naming.bastion_host.name_unique}-ipconf"
+#     subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
+#     public_ip_address_id = azurerm_public_ip.bastionpip.id
+#   }
+# }
 
 data "azurerm_client_config" "current" {}
 

--- a/examples/linux_vmss_flex_vm_attach/README.md
+++ b/examples/linux_vmss_flex_vm_attach/README.md
@@ -149,27 +149,26 @@ module "vnet" {
   }
 }
 
-/* Uncomment this section if you would like to include a bastion resource with this example.
-resource "azurerm_public_ip" "bastionpip" {
-  name                = module.naming.public_ip.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-  allocation_method   = "Static"
-  sku                 = "Standard"
-}
-
-resource "azurerm_bastion_host" "bastion" {
-  name                = module.naming.bastion_host.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-
-  ip_configuration {
-    name                 = "${module.naming.bastion_host.name_unique}-ipconf"
-    subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
-    public_ip_address_id = azurerm_public_ip.bastionpip.id
-  }
-}
-*/
+# Uncomment this section if you would like to include a bastion resource with this example.
+# resource "azurerm_public_ip" "bastionpip" {
+#   name                = module.naming.public_ip.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#   allocation_method   = "Static"
+#   sku                 = "Standard"
+# }
+#
+# resource "azurerm_bastion_host" "bastion" {
+#   name                = module.naming.bastion_host.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#
+#   ip_configuration {
+#     name                 = "${module.naming.bastion_host.name_unique}-ipconf"
+#     subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
+#     public_ip_address_id = azurerm_public_ip.bastionpip.id
+#   }
+# }
 
 
 data "azurerm_client_config" "current" {}

--- a/examples/linux_vmss_flex_vm_attach/main.tf
+++ b/examples/linux_vmss_flex_vm_attach/main.tf
@@ -128,27 +128,26 @@ module "vnet" {
   }
 }
 
-/* Uncomment this section if you would like to include a bastion resource with this example.
-resource "azurerm_public_ip" "bastionpip" {
-  name                = module.naming.public_ip.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-  allocation_method   = "Static"
-  sku                 = "Standard"
-}
-
-resource "azurerm_bastion_host" "bastion" {
-  name                = module.naming.bastion_host.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-
-  ip_configuration {
-    name                 = "${module.naming.bastion_host.name_unique}-ipconf"
-    subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
-    public_ip_address_id = azurerm_public_ip.bastionpip.id
-  }
-}
-*/
+# Uncomment this section if you would like to include a bastion resource with this example.
+# resource "azurerm_public_ip" "bastionpip" {
+#   name                = module.naming.public_ip.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#   allocation_method   = "Static"
+#   sku                 = "Standard"
+# }
+#
+# resource "azurerm_bastion_host" "bastion" {
+#   name                = module.naming.bastion_host.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#
+#   ip_configuration {
+#     name                 = "${module.naming.bastion_host.name_unique}-ipconf"
+#     subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
+#     public_ip_address_id = azurerm_public_ip.bastionpip.id
+#   }
+# }
 
 
 data "azurerm_client_config" "current" {}

--- a/examples/linux_zonal_vm_with_zrs_disk/README.md
+++ b/examples/linux_zonal_vm_with_zrs_disk/README.md
@@ -149,27 +149,26 @@ module "vnet" {
   }
 }
 
-/* Uncomment this section if you would like to include a bastion resource with this example.
-resource "azurerm_public_ip" "bastionpip" {
-  name                = module.naming.public_ip.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-  allocation_method   = "Static"
-  sku                 = "Standard"
-}
-
-resource "azurerm_bastion_host" "bastion" {
-  name                = module.naming.bastion_host.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-
-  ip_configuration {
-    name                 = "${module.naming.bastion_host.name_unique}-ipconf"
-    subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
-    public_ip_address_id = azurerm_public_ip.bastionpip.id
-  }
-}
-*/
+# Uncomment this section if you would like to include a bastion resource with this example.
+# resource "azurerm_public_ip" "bastionpip" {
+#   name                = module.naming.public_ip.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#   allocation_method   = "Static"
+#   sku                 = "Standard"
+# }
+#
+# resource "azurerm_bastion_host" "bastion" {
+#   name                = module.naming.bastion_host.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#
+#   ip_configuration {
+#     name                 = "${module.naming.bastion_host.name_unique}-ipconf"
+#     subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
+#     public_ip_address_id = azurerm_public_ip.bastionpip.id
+#   }
+# }
 
 data "azurerm_client_config" "current" {}
 

--- a/examples/linux_zonal_vm_with_zrs_disk/main.tf
+++ b/examples/linux_zonal_vm_with_zrs_disk/main.tf
@@ -128,27 +128,26 @@ module "vnet" {
   }
 }
 
-/* Uncomment this section if you would like to include a bastion resource with this example.
-resource "azurerm_public_ip" "bastionpip" {
-  name                = module.naming.public_ip.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-  allocation_method   = "Static"
-  sku                 = "Standard"
-}
-
-resource "azurerm_bastion_host" "bastion" {
-  name                = module.naming.bastion_host.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-
-  ip_configuration {
-    name                 = "${module.naming.bastion_host.name_unique}-ipconf"
-    subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
-    public_ip_address_id = azurerm_public_ip.bastionpip.id
-  }
-}
-*/
+# Uncomment this section if you would like to include a bastion resource with this example.
+# resource "azurerm_public_ip" "bastionpip" {
+#   name                = module.naming.public_ip.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#   allocation_method   = "Static"
+#   sku                 = "Standard"
+# }
+#
+# resource "azurerm_bastion_host" "bastion" {
+#   name                = module.naming.bastion_host.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#
+#   ip_configuration {
+#     name                 = "${module.naming.bastion_host.name_unique}-ipconf"
+#     subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
+#     public_ip_address_id = azurerm_public_ip.bastionpip.id
+#   }
+# }
 
 data "azurerm_client_config" "current" {}
 

--- a/examples/windows_minimal/README.md
+++ b/examples/windows_minimal/README.md
@@ -135,27 +135,26 @@ module "vnet" {
   }
 }
 
-/* Uncomment this section if you would like to include a bastion resource with this example.
-resource "azurerm_public_ip" "bastionpip" {
-  name                = module.naming.public_ip.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-  allocation_method   = "Static"
-  sku                 = "Standard"
-}
-
-resource "azurerm_bastion_host" "bastion" {
-  name                = module.naming.bastion_host.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-
-  ip_configuration {
-    name                 = "${module.naming.bastion_host.name_unique}-ipconf"
-    subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
-    public_ip_address_id = azurerm_public_ip.bastionpip.id
-  }
-}
-*/
+# Uncomment this section if you would like to include a bastion resource with this example.
+# resource "azurerm_public_ip" "bastionpip" {
+#   name                = module.naming.public_ip.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#   allocation_method   = "Static"
+#   sku                 = "Standard"
+# }
+#
+# resource "azurerm_bastion_host" "bastion" {
+#   name                = module.naming.bastion_host.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#
+#   ip_configuration {
+#     name                 = "${module.naming.bastion_host.name_unique}-ipconf"
+#     subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
+#     public_ip_address_id = azurerm_public_ip.bastionpip.id
+#   }
+# }
 
 module "testvm" {
   source = "../../"

--- a/examples/windows_minimal/main.tf
+++ b/examples/windows_minimal/main.tf
@@ -128,27 +128,26 @@ module "vnet" {
   }
 }
 
-/* Uncomment this section if you would like to include a bastion resource with this example.
-resource "azurerm_public_ip" "bastionpip" {
-  name                = module.naming.public_ip.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-  allocation_method   = "Static"
-  sku                 = "Standard"
-}
-
-resource "azurerm_bastion_host" "bastion" {
-  name                = module.naming.bastion_host.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-
-  ip_configuration {
-    name                 = "${module.naming.bastion_host.name_unique}-ipconf"
-    subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
-    public_ip_address_id = azurerm_public_ip.bastionpip.id
-  }
-}
-*/
+# Uncomment this section if you would like to include a bastion resource with this example.
+# resource "azurerm_public_ip" "bastionpip" {
+#   name                = module.naming.public_ip.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#   allocation_method   = "Static"
+#   sku                 = "Standard"
+# }
+#
+# resource "azurerm_bastion_host" "bastion" {
+#   name                = module.naming.bastion_host.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#
+#   ip_configuration {
+#     name                 = "${module.naming.bastion_host.name_unique}-ipconf"
+#     subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
+#     public_ip_address_id = azurerm_public_ip.bastionpip.id
+#   }
+# }
 
 module "testvm" {
   source = "../../"

--- a/examples/windows_w_additional_disks_public_ip/README.md
+++ b/examples/windows_w_additional_disks_public_ip/README.md
@@ -149,28 +149,27 @@ module "vnet" {
 }
 
 
-/* Uncomment this section if you would like to include a bastion resource with this example.
-resource "azurerm_public_ip" "bastionpip" {
-  allocation_method   = "Static"
-  location            = azurerm_resource_group.this_rg.location
-  name                = "${module.naming.public_ip.name_unique}-bastion"
-  resource_group_name = azurerm_resource_group.this_rg.name
-  sku                 = "Standard"
-
-}
-
-resource "azurerm_bastion_host" "bastion" {
-  location            = azurerm_resource_group.this_rg.location
-  name                = module.naming.bastion_host.name_unique
-  resource_group_name = azurerm_resource_group.this_rg.name
-
-  ip_configuration {
-    name                 = "${module.naming.bastion_host.name_unique}-ipconf"
-    public_ip_address_id = azurerm_public_ip.bastionpip.id
-    subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
-  }
-}
-*/
+# Uncomment this section if you would like to include a bastion resource with this example.
+# resource "azurerm_public_ip" "bastionpip" {
+#   allocation_method   = "Static"
+#   location            = azurerm_resource_group.this_rg.location
+#   name                = "${module.naming.public_ip.name_unique}-bastion"
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#   sku                 = "Standard"
+#
+# }
+#
+# resource "azurerm_bastion_host" "bastion" {
+#   location            = azurerm_resource_group.this_rg.location
+#   name                = module.naming.bastion_host.name_unique
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#
+#   ip_configuration {
+#     name                 = "${module.naming.bastion_host.name_unique}-ipconf"
+#     public_ip_address_id = azurerm_public_ip.bastionpip.id
+#     subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
+#   }
+# }
 
 data "azurerm_client_config" "current" {}
 

--- a/examples/windows_w_additional_disks_public_ip/main.tf
+++ b/examples/windows_w_additional_disks_public_ip/main.tf
@@ -129,28 +129,27 @@ module "vnet" {
 }
 
 
-/* Uncomment this section if you would like to include a bastion resource with this example.
-resource "azurerm_public_ip" "bastionpip" {
-  allocation_method   = "Static"
-  location            = azurerm_resource_group.this_rg.location
-  name                = "${module.naming.public_ip.name_unique}-bastion"
-  resource_group_name = azurerm_resource_group.this_rg.name
-  sku                 = "Standard"
-
-}
-
-resource "azurerm_bastion_host" "bastion" {
-  location            = azurerm_resource_group.this_rg.location
-  name                = module.naming.bastion_host.name_unique
-  resource_group_name = azurerm_resource_group.this_rg.name
-
-  ip_configuration {
-    name                 = "${module.naming.bastion_host.name_unique}-ipconf"
-    public_ip_address_id = azurerm_public_ip.bastionpip.id
-    subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
-  }
-}
-*/
+# Uncomment this section if you would like to include a bastion resource with this example.
+# resource "azurerm_public_ip" "bastionpip" {
+#   allocation_method   = "Static"
+#   location            = azurerm_resource_group.this_rg.location
+#   name                = "${module.naming.public_ip.name_unique}-bastion"
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#   sku                 = "Standard"
+#
+# }
+#
+# resource "azurerm_bastion_host" "bastion" {
+#   location            = azurerm_resource_group.this_rg.location
+#   name                = module.naming.bastion_host.name_unique
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#
+#   ip_configuration {
+#     name                 = "${module.naming.bastion_host.name_unique}-ipconf"
+#     public_ip_address_id = azurerm_public_ip.bastionpip.id
+#     subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
+#   }
+# }
 
 data "azurerm_client_config" "current" {}
 

--- a/examples/windows_w_azure_monitor_agent/README.md
+++ b/examples/windows_w_azure_monitor_agent/README.md
@@ -151,27 +151,26 @@ module "vnet" {
 }
 
 
-/* Uncomment this section if you would like to include a bastion resource with this example.
-resource "azurerm_public_ip" "bastionpip" {
-  name                = module.naming.public_ip.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-  allocation_method   = "Static"
-  sku                 = "Standard"
-}
-
-resource "azurerm_bastion_host" "bastion" {
-  name                = module.naming.bastion_host.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-
-  ip_configuration {
-    name                 = "${module.naming.bastion_host.name_unique}-ipconf"
-    subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
-    public_ip_address_id = azurerm_public_ip.bastionpip.id
-  }
-}
-*/
+# Uncomment this section if you would like to include a bastion resource with this example.
+# resource "azurerm_public_ip" "bastionpip" {
+#   name                = module.naming.public_ip.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#   allocation_method   = "Static"
+#   sku                 = "Standard"
+# }
+#
+# resource "azurerm_bastion_host" "bastion" {
+#   name                = module.naming.bastion_host.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#
+#   ip_configuration {
+#     name                 = "${module.naming.bastion_host.name_unique}-ipconf"
+#     subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
+#     public_ip_address_id = azurerm_public_ip.bastionpip.id
+#   }
+# }
 
 data "azurerm_client_config" "current" {}
 

--- a/examples/windows_w_azure_monitor_agent/main.tf
+++ b/examples/windows_w_azure_monitor_agent/main.tf
@@ -129,27 +129,26 @@ module "vnet" {
 }
 
 
-/* Uncomment this section if you would like to include a bastion resource with this example.
-resource "azurerm_public_ip" "bastionpip" {
-  name                = module.naming.public_ip.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-  allocation_method   = "Static"
-  sku                 = "Standard"
-}
-
-resource "azurerm_bastion_host" "bastion" {
-  name                = module.naming.bastion_host.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-
-  ip_configuration {
-    name                 = "${module.naming.bastion_host.name_unique}-ipconf"
-    subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
-    public_ip_address_id = azurerm_public_ip.bastionpip.id
-  }
-}
-*/
+# Uncomment this section if you would like to include a bastion resource with this example.
+# resource "azurerm_public_ip" "bastionpip" {
+#   name                = module.naming.public_ip.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#   allocation_method   = "Static"
+#   sku                 = "Standard"
+# }
+#
+# resource "azurerm_bastion_host" "bastion" {
+#   name                = module.naming.bastion_host.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#
+#   ip_configuration {
+#     name                 = "${module.naming.bastion_host.name_unique}-ipconf"
+#     subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
+#     public_ip_address_id = azurerm_public_ip.bastionpip.id
+#   }
+# }
 
 data "azurerm_client_config" "current" {}
 

--- a/examples/windows_w_encryption_at_host/README.md
+++ b/examples/windows_w_encryption_at_host/README.md
@@ -151,28 +151,26 @@ module "vnet" {
   }
 }
 
-/*
-# Uncomment this section if you would like to include a bastion resource with this example.
-resource "azurerm_public_ip" "bastionpip" {
-  name                = module.naming.public_ip.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-  allocation_method   = "Static"
-  sku                 = "Standard"
-}
-
-resource "azurerm_bastion_host" "bastion" {
-  name                = module.naming.bastion_host.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-
-  ip_configuration {
-    name                 = "${module.naming.bastion_host.name_unique}-ipconf"
-    subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
-    public_ip_address_id = azurerm_public_ip.bastionpip.id
-  }
-}
-*/
+# # Uncomment this section if you would like to include a bastion resource with this example.
+# resource "azurerm_public_ip" "bastionpip" {
+#   name                = module.naming.public_ip.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#   allocation_method   = "Static"
+#   sku                 = "Standard"
+# }
+#
+# resource "azurerm_bastion_host" "bastion" {
+#   name                = module.naming.bastion_host.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#
+#   ip_configuration {
+#     name                 = "${module.naming.bastion_host.name_unique}-ipconf"
+#     subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
+#     public_ip_address_id = azurerm_public_ip.bastionpip.id
+#   }
+# }
 
 data "azurerm_client_config" "current" {}
 

--- a/examples/windows_w_encryption_at_host/main.tf
+++ b/examples/windows_w_encryption_at_host/main.tf
@@ -128,28 +128,26 @@ module "vnet" {
   }
 }
 
-/*
-# Uncomment this section if you would like to include a bastion resource with this example.
-resource "azurerm_public_ip" "bastionpip" {
-  name                = module.naming.public_ip.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-  allocation_method   = "Static"
-  sku                 = "Standard"
-}
-
-resource "azurerm_bastion_host" "bastion" {
-  name                = module.naming.bastion_host.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-
-  ip_configuration {
-    name                 = "${module.naming.bastion_host.name_unique}-ipconf"
-    subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
-    public_ip_address_id = azurerm_public_ip.bastionpip.id
-  }
-}
-*/
+# # Uncomment this section if you would like to include a bastion resource with this example.
+# resource "azurerm_public_ip" "bastionpip" {
+#   name                = module.naming.public_ip.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#   allocation_method   = "Static"
+#   sku                 = "Standard"
+# }
+#
+# resource "azurerm_bastion_host" "bastion" {
+#   name                = module.naming.bastion_host.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#
+#   ip_configuration {
+#     name                 = "${module.naming.bastion_host.name_unique}-ipconf"
+#     subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
+#     public_ip_address_id = azurerm_public_ip.bastionpip.id
+#   }
+# }
 
 data "azurerm_client_config" "current" {}
 

--- a/examples/windows_w_gallery_application/README.md
+++ b/examples/windows_w_gallery_application/README.md
@@ -159,27 +159,26 @@ module "vnet" {
   }
 }
 
-/* #uncomment these resources to enable bastion
-resource "azurerm_public_ip" "bastionpip" {
-  allocation_method   = "Static"
-  location            = azurerm_resource_group.this_rg.location
-  name                = "${module.naming.public_ip.name_unique}-bastion"
-  resource_group_name = azurerm_resource_group.this_rg.name
-  sku                 = "Standard"
-}
-
-resource "azurerm_bastion_host" "bastion" {
-  location            = azurerm_resource_group.this_rg.location
-  name                = module.naming.bastion_host.name_unique
-  resource_group_name = azurerm_resource_group.this_rg.name
-
-  ip_configuration {
-    name                 = "${module.naming.bastion_host.name_unique}-ipconf"
-    public_ip_address_id = azurerm_public_ip.bastionpip.id
-    subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
-  }
-}
-*/
+# #uncomment these resources to enable bastion
+# resource "azurerm_public_ip" "bastionpip" {
+#   allocation_method   = "Static"
+#   location            = azurerm_resource_group.this_rg.location
+#   name                = "${module.naming.public_ip.name_unique}-bastion"
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#   sku                 = "Standard"
+# }
+#
+# resource "azurerm_bastion_host" "bastion" {
+#   location            = azurerm_resource_group.this_rg.location
+#   name                = module.naming.bastion_host.name_unique
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#
+#   ip_configuration {
+#     name                 = "${module.naming.bastion_host.name_unique}-ipconf"
+#     public_ip_address_id = azurerm_public_ip.bastionpip.id
+#     subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
+#   }
+# }
 
 data "azurerm_client_config" "current" {}
 

--- a/examples/windows_w_gallery_application/main.tf
+++ b/examples/windows_w_gallery_application/main.tf
@@ -133,27 +133,26 @@ module "vnet" {
   }
 }
 
-/* #uncomment these resources to enable bastion
-resource "azurerm_public_ip" "bastionpip" {
-  allocation_method   = "Static"
-  location            = azurerm_resource_group.this_rg.location
-  name                = "${module.naming.public_ip.name_unique}-bastion"
-  resource_group_name = azurerm_resource_group.this_rg.name
-  sku                 = "Standard"
-}
-
-resource "azurerm_bastion_host" "bastion" {
-  location            = azurerm_resource_group.this_rg.location
-  name                = module.naming.bastion_host.name_unique
-  resource_group_name = azurerm_resource_group.this_rg.name
-
-  ip_configuration {
-    name                 = "${module.naming.bastion_host.name_unique}-ipconf"
-    public_ip_address_id = azurerm_public_ip.bastionpip.id
-    subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
-  }
-}
-*/
+# #uncomment these resources to enable bastion
+# resource "azurerm_public_ip" "bastionpip" {
+#   allocation_method   = "Static"
+#   location            = azurerm_resource_group.this_rg.location
+#   name                = "${module.naming.public_ip.name_unique}-bastion"
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#   sku                 = "Standard"
+# }
+#
+# resource "azurerm_bastion_host" "bastion" {
+#   location            = azurerm_resource_group.this_rg.location
+#   name                = module.naming.bastion_host.name_unique
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#
+#   ip_configuration {
+#     name                 = "${module.naming.bastion_host.name_unique}-ipconf"
+#     public_ip_address_id = azurerm_public_ip.bastionpip.id
+#     subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
+#   }
+# }
 
 data "azurerm_client_config" "current" {}
 

--- a/examples/windows_w_load_balancing/README.md
+++ b/examples/windows_w_load_balancing/README.md
@@ -165,28 +165,26 @@ module "vnet" {
 }
 
 
-/*
-# Uncomment this section if you would like to include a bastion resource with this example.
-resource "azurerm_public_ip" "bastionpip" {
-  name                = module.naming.public_ip.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-  allocation_method   = "Static"
-  sku                 = "Standard"
-}
-
-resource "azurerm_bastion_host" "bastion" {
-  name                = module.naming.bastion_host.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-
-  ip_configuration {
-    name                 = "${module.naming.bastion_host.name_unique}-ipconf"
-    subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
-    public_ip_address_id = azurerm_public_ip.bastionpip.id
-  }
-}
-*/
+# # Uncomment this section if you would like to include a bastion resource with this example.
+# resource "azurerm_public_ip" "bastionpip" {
+#   name                = module.naming.public_ip.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#   allocation_method   = "Static"
+#   sku                 = "Standard"
+# }
+#
+# resource "azurerm_bastion_host" "bastion" {
+#   name                = module.naming.bastion_host.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#
+#   ip_configuration {
+#     name                 = "${module.naming.bastion_host.name_unique}-ipconf"
+#     subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
+#     public_ip_address_id = azurerm_public_ip.bastionpip.id
+#   }
+# }
 
 module "loadbalancer" {
   source  = "Azure/avm-res-network-loadbalancer/azurerm"

--- a/examples/windows_w_load_balancing/main.tf
+++ b/examples/windows_w_load_balancing/main.tf
@@ -142,28 +142,26 @@ module "vnet" {
 }
 
 
-/*
-# Uncomment this section if you would like to include a bastion resource with this example.
-resource "azurerm_public_ip" "bastionpip" {
-  name                = module.naming.public_ip.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-  allocation_method   = "Static"
-  sku                 = "Standard"
-}
-
-resource "azurerm_bastion_host" "bastion" {
-  name                = module.naming.bastion_host.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-
-  ip_configuration {
-    name                 = "${module.naming.bastion_host.name_unique}-ipconf"
-    subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
-    public_ip_address_id = azurerm_public_ip.bastionpip.id
-  }
-}
-*/
+# # Uncomment this section if you would like to include a bastion resource with this example.
+# resource "azurerm_public_ip" "bastionpip" {
+#   name                = module.naming.public_ip.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#   allocation_method   = "Static"
+#   sku                 = "Standard"
+# }
+#
+# resource "azurerm_bastion_host" "bastion" {
+#   name                = module.naming.bastion_host.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#
+#   ip_configuration {
+#     name                 = "${module.naming.bastion_host.name_unique}-ipconf"
+#     subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
+#     public_ip_address_id = azurerm_public_ip.bastionpip.id
+#   }
+# }
 
 module "loadbalancer" {
   source  = "Azure/avm-res-network-loadbalancer/azurerm"

--- a/examples/windows_w_managed_identities_and_rbac/README.md
+++ b/examples/windows_w_managed_identities_and_rbac/README.md
@@ -151,27 +151,26 @@ module "vnet" {
   }
 }
 
-/* Uncomment this section if you would like to include a bastion resource with this example.
-resource "azurerm_public_ip" "bastionpip" {
-  name                = module.naming.public_ip.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-  allocation_method   = "Static"
-  sku                 = "Standard"
-}
-
-resource "azurerm_bastion_host" "bastion" {
-  name                = module.naming.bastion_host.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-
-  ip_configuration {
-    name                 = "${module.naming.bastion_host.name_unique}-ipconf"
-    subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
-    public_ip_address_id = azurerm_public_ip.bastionpip.id
-  }
-}
-*/
+# Uncomment this section if you would like to include a bastion resource with this example.
+# resource "azurerm_public_ip" "bastionpip" {
+#   name                = module.naming.public_ip.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#   allocation_method   = "Static"
+#   sku                 = "Standard"
+# }
+#
+# resource "azurerm_bastion_host" "bastion" {
+#   name                = module.naming.bastion_host.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#
+#   ip_configuration {
+#     name                 = "${module.naming.bastion_host.name_unique}-ipconf"
+#     subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
+#     public_ip_address_id = azurerm_public_ip.bastionpip.id
+#   }
+# }
 
 data "azurerm_client_config" "current" {}
 

--- a/examples/windows_w_managed_identities_and_rbac/main.tf
+++ b/examples/windows_w_managed_identities_and_rbac/main.tf
@@ -128,27 +128,26 @@ module "vnet" {
   }
 }
 
-/* Uncomment this section if you would like to include a bastion resource with this example.
-resource "azurerm_public_ip" "bastionpip" {
-  name                = module.naming.public_ip.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-  allocation_method   = "Static"
-  sku                 = "Standard"
-}
-
-resource "azurerm_bastion_host" "bastion" {
-  name                = module.naming.bastion_host.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-
-  ip_configuration {
-    name                 = "${module.naming.bastion_host.name_unique}-ipconf"
-    subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
-    public_ip_address_id = azurerm_public_ip.bastionpip.id
-  }
-}
-*/
+# Uncomment this section if you would like to include a bastion resource with this example.
+# resource "azurerm_public_ip" "bastionpip" {
+#   name                = module.naming.public_ip.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#   allocation_method   = "Static"
+#   sku                 = "Standard"
+# }
+#
+# resource "azurerm_bastion_host" "bastion" {
+#   name                = module.naming.bastion_host.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#
+#   ip_configuration {
+#     name                 = "${module.naming.bastion_host.name_unique}-ipconf"
+#     subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
+#     public_ip_address_id = azurerm_public_ip.bastionpip.id
+#   }
+# }
 
 data "azurerm_client_config" "current" {}
 

--- a/examples/windows_w_os_disk_network_access/README.md
+++ b/examples/windows_w_os_disk_network_access/README.md
@@ -137,27 +137,26 @@ module "vnet" {
   }
 }
 
-/* Uncomment this section if you would like to include a bastion resource with this example.
-resource "azurerm_public_ip" "bastionpip" {
-  name                = module.naming.public_ip.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-  allocation_method   = "Static"
-  sku                 = "Standard"
-}
-
-resource "azurerm_bastion_host" "bastion" {
-  name                = module.naming.bastion_host.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-
-  ip_configuration {
-    name                 = "${module.naming.bastion_host.name_unique}-ipconf"
-    subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
-    public_ip_address_id = azurerm_public_ip.bastionpip.id
-  }
-}
-*/
+# Uncomment this section if you would like to include a bastion resource with this example.
+# resource "azurerm_public_ip" "bastionpip" {
+#   name                = module.naming.public_ip.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#   allocation_method   = "Static"
+#   sku                 = "Standard"
+# }
+#
+# resource "azurerm_bastion_host" "bastion" {
+#   name                = module.naming.bastion_host.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#
+#   ip_configuration {
+#     name                 = "${module.naming.bastion_host.name_unique}-ipconf"
+#     subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
+#     public_ip_address_id = azurerm_public_ip.bastionpip.id
+#   }
+# }
 
 module "testvm" {
   source = "../../"

--- a/examples/windows_w_os_disk_network_access/main.tf
+++ b/examples/windows_w_os_disk_network_access/main.tf
@@ -128,27 +128,26 @@ module "vnet" {
   }
 }
 
-/* Uncomment this section if you would like to include a bastion resource with this example.
-resource "azurerm_public_ip" "bastionpip" {
-  name                = module.naming.public_ip.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-  allocation_method   = "Static"
-  sku                 = "Standard"
-}
-
-resource "azurerm_bastion_host" "bastion" {
-  name                = module.naming.bastion_host.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-
-  ip_configuration {
-    name                 = "${module.naming.bastion_host.name_unique}-ipconf"
-    subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
-    public_ip_address_id = azurerm_public_ip.bastionpip.id
-  }
-}
-*/
+# Uncomment this section if you would like to include a bastion resource with this example.
+# resource "azurerm_public_ip" "bastionpip" {
+#   name                = module.naming.public_ip.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#   allocation_method   = "Static"
+#   sku                 = "Standard"
+# }
+#
+# resource "azurerm_bastion_host" "bastion" {
+#   name                = module.naming.bastion_host.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#
+#   ip_configuration {
+#     name                 = "${module.naming.bastion_host.name_unique}-ipconf"
+#     subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
+#     public_ip_address_id = azurerm_public_ip.bastionpip.id
+#   }
+# }
 
 module "testvm" {
   source = "../../"

--- a/examples/windows_w_remote_access/README.md
+++ b/examples/windows_w_remote_access/README.md
@@ -189,27 +189,26 @@ resource "azurerm_network_security_group" "remote" {
   }
 }
 
-/* Uncomment this section if you would like to include a bastion resource with this example.
-resource "azurerm_public_ip" "bastionpip" {
-  name                = module.naming.public_ip.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-  allocation_method   = "Static"
-  sku                 = "Standard"
-}
-
-resource "azurerm_bastion_host" "bastion" {
-  name                = module.naming.bastion_host.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-
-  ip_configuration {
-    name                 = "${module.naming.bastion_host.name_unique}-ipconf"
-    subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
-    public_ip_address_id = azurerm_public_ip.bastionpip.id
-  }
-}
-*/
+# Uncomment this section if you would like to include a bastion resource with this example.
+# resource "azurerm_public_ip" "bastionpip" {
+#   name                = module.naming.public_ip.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#   allocation_method   = "Static"
+#   sku                 = "Standard"
+# }
+#
+# resource "azurerm_bastion_host" "bastion" {
+#   name                = module.naming.bastion_host.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#
+#   ip_configuration {
+#     name                 = "${module.naming.bastion_host.name_unique}-ipconf"
+#     subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
+#     public_ip_address_id = azurerm_public_ip.bastionpip.id
+#   }
+# }
 
 
 data "azurerm_client_config" "current" {}

--- a/examples/windows_w_remote_access/main.tf
+++ b/examples/windows_w_remote_access/main.tf
@@ -164,27 +164,26 @@ resource "azurerm_network_security_group" "remote" {
   }
 }
 
-/* Uncomment this section if you would like to include a bastion resource with this example.
-resource "azurerm_public_ip" "bastionpip" {
-  name                = module.naming.public_ip.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-  allocation_method   = "Static"
-  sku                 = "Standard"
-}
-
-resource "azurerm_bastion_host" "bastion" {
-  name                = module.naming.bastion_host.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-
-  ip_configuration {
-    name                 = "${module.naming.bastion_host.name_unique}-ipconf"
-    subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
-    public_ip_address_id = azurerm_public_ip.bastionpip.id
-  }
-}
-*/
+# Uncomment this section if you would like to include a bastion resource with this example.
+# resource "azurerm_public_ip" "bastionpip" {
+#   name                = module.naming.public_ip.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#   allocation_method   = "Static"
+#   sku                 = "Standard"
+# }
+#
+# resource "azurerm_bastion_host" "bastion" {
+#   name                = module.naming.bastion_host.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#
+#   ip_configuration {
+#     name                 = "${module.naming.bastion_host.name_unique}-ipconf"
+#     subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
+#     public_ip_address_id = azurerm_public_ip.bastionpip.id
+#   }
+# }
 
 
 data "azurerm_client_config" "current" {}

--- a/examples/windows_w_run_command/README.md
+++ b/examples/windows_w_run_command/README.md
@@ -148,28 +148,26 @@ module "vnet" {
   }
 }
 
-/*
-#uncomment this block to enable bastion host
-resource "azurerm_public_ip" "bastionpip" {
-  allocation_method   = "Static"
-  location            = azurerm_resource_group.this_rg.location
-  name                = module.naming.public_ip.name_unique
-  resource_group_name = azurerm_resource_group.this_rg.name
-  sku                 = "Standard"
-}
-
-resource "azurerm_bastion_host" "bastion" {
-  location            = azurerm_resource_group.this_rg.location
-  name                = module.naming.bastion_host.name_unique
-  resource_group_name = azurerm_resource_group.this_rg.name
-
-  ip_configuration {
-    name                 = "${module.naming.bastion_host.name_unique}-ipconf"
-    public_ip_address_id = azurerm_public_ip.bastionpip.id
-    subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
-  }
-}
-*/
+# #uncomment this block to enable bastion host
+# resource "azurerm_public_ip" "bastionpip" {
+#   allocation_method   = "Static"
+#   location            = azurerm_resource_group.this_rg.location
+#   name                = module.naming.public_ip.name_unique
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#   sku                 = "Standard"
+# }
+#
+# resource "azurerm_bastion_host" "bastion" {
+#   location            = azurerm_resource_group.this_rg.location
+#   name                = module.naming.bastion_host.name_unique
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#
+#   ip_configuration {
+#     name                 = "${module.naming.bastion_host.name_unique}-ipconf"
+#     public_ip_address_id = azurerm_public_ip.bastionpip.id
+#     subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
+#   }
+# }
 
 data "azurerm_client_config" "current" {}
 

--- a/examples/windows_w_run_command/main.tf
+++ b/examples/windows_w_run_command/main.tf
@@ -128,28 +128,26 @@ module "vnet" {
   }
 }
 
-/*
-#uncomment this block to enable bastion host
-resource "azurerm_public_ip" "bastionpip" {
-  allocation_method   = "Static"
-  location            = azurerm_resource_group.this_rg.location
-  name                = module.naming.public_ip.name_unique
-  resource_group_name = azurerm_resource_group.this_rg.name
-  sku                 = "Standard"
-}
-
-resource "azurerm_bastion_host" "bastion" {
-  location            = azurerm_resource_group.this_rg.location
-  name                = module.naming.bastion_host.name_unique
-  resource_group_name = azurerm_resource_group.this_rg.name
-
-  ip_configuration {
-    name                 = "${module.naming.bastion_host.name_unique}-ipconf"
-    public_ip_address_id = azurerm_public_ip.bastionpip.id
-    subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
-  }
-}
-*/
+# #uncomment this block to enable bastion host
+# resource "azurerm_public_ip" "bastionpip" {
+#   allocation_method   = "Static"
+#   location            = azurerm_resource_group.this_rg.location
+#   name                = module.naming.public_ip.name_unique
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#   sku                 = "Standard"
+# }
+#
+# resource "azurerm_bastion_host" "bastion" {
+#   location            = azurerm_resource_group.this_rg.location
+#   name                = module.naming.bastion_host.name_unique
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#
+#   ip_configuration {
+#     name                 = "${module.naming.bastion_host.name_unique}-ipconf"
+#     public_ip_address_id = azurerm_public_ip.bastionpip.id
+#     subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
+#   }
+# }
 
 data "azurerm_client_config" "current" {}
 

--- a/examples/windows_waf/README.md
+++ b/examples/windows_waf/README.md
@@ -166,27 +166,26 @@ module "vnet" {
 }
 
 
-/* Uncomment this section if you would like to include a bastion resource with this example.
-resource "azurerm_public_ip" "bastionpip" {
-  name                = module.naming.public_ip.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-  allocation_method   = "Static"
-  sku                 = "Standard"
-}
-
-resource "azurerm_bastion_host" "bastion" {
-  name                = module.naming.bastion_host.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-
-  ip_configuration {
-    name                 = "${module.naming.bastion_host.name_unique}-ipconf"
-    subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
-    public_ip_address_id = azurerm_public_ip.bastionpip.id
-  }
-}
-*/
+# Uncomment this section if you would like to include a bastion resource with this example.
+# resource "azurerm_public_ip" "bastionpip" {
+#   name                = module.naming.public_ip.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#   allocation_method   = "Static"
+#   sku                 = "Standard"
+# }
+#
+# resource "azurerm_bastion_host" "bastion" {
+#   name                = module.naming.bastion_host.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#
+#   ip_configuration {
+#     name                 = "${module.naming.bastion_host.name_unique}-ipconf"
+#     subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
+#     public_ip_address_id = azurerm_public_ip.bastionpip.id
+#   }
+# }
 
 data "azurerm_client_config" "current" {}
 

--- a/examples/windows_waf/main.tf
+++ b/examples/windows_waf/main.tf
@@ -138,27 +138,26 @@ module "vnet" {
 }
 
 
-/* Uncomment this section if you would like to include a bastion resource with this example.
-resource "azurerm_public_ip" "bastionpip" {
-  name                = module.naming.public_ip.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-  allocation_method   = "Static"
-  sku                 = "Standard"
-}
-
-resource "azurerm_bastion_host" "bastion" {
-  name                = module.naming.bastion_host.name_unique
-  location            = azurerm_resource_group.this_rg.location
-  resource_group_name = azurerm_resource_group.this_rg.name
-
-  ip_configuration {
-    name                 = "${module.naming.bastion_host.name_unique}-ipconf"
-    subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
-    public_ip_address_id = azurerm_public_ip.bastionpip.id
-  }
-}
-*/
+# Uncomment this section if you would like to include a bastion resource with this example.
+# resource "azurerm_public_ip" "bastionpip" {
+#   name                = module.naming.public_ip.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#   allocation_method   = "Static"
+#   sku                 = "Standard"
+# }
+#
+# resource "azurerm_bastion_host" "bastion" {
+#   name                = module.naming.bastion_host.name_unique
+#   location            = azurerm_resource_group.this_rg.location
+#   resource_group_name = azurerm_resource_group.this_rg.name
+#
+#   ip_configuration {
+#     name                 = "${module.naming.bastion_host.name_unique}-ipconf"
+#     subnet_id            = module.vnet.subnets["AzureBastionSubnet"].resource_id
+#     public_ip_address_id = azurerm_public_ip.bastionpip.id
+#   }
+# }
 
 data "azurerm_client_config" "current" {}
 

--- a/locals.os_versions.tf
+++ b/locals.os_versions.tf
@@ -1,12 +1,10 @@
 #Future functionality for aliasing common OS versions
-/*
-locals {
-  os_map = {
-    ubuntu = {
-      publisher = "Canonical"
-      v1_offer  = "UbuntuServer"
-
-    }
-  }
-}
-*/
+# locals {
+#   os_map = {
+#     ubuntu = {
+#       publisher = "Canonical"
+#       v1_offer  = "UbuntuServer"
+#
+#     }
+#   }
+# }

--- a/main.maintenance_configurations.tf
+++ b/main.maintenance_configurations.tf
@@ -1,17 +1,15 @@
-/*
-resource "azurerm_maintenance_assignment_virtual_machine" "this" {
-  for_each = var.maintenance_configuration_resource_ids
-
-  location                     = var.location
-  maintenance_configuration_id = each.value
-  virtual_machine_id           = local.virtualmachine_resource_id
-
-  depends_on = [
-    azurerm_virtual_machine_data_disk_attachment.this_linux,
-    azurerm_virtual_machine_data_disk_attachment.this_windows
-  ]
-}
-*/
+# resource "azurerm_maintenance_assignment_virtual_machine" "this" {
+#   for_each = var.maintenance_configuration_resource_ids
+#
+#   location                     = var.location
+#   maintenance_configuration_id = each.value
+#   virtual_machine_id           = local.virtualmachine_resource_id
+#
+#   depends_on = [
+#     azurerm_virtual_machine_data_disk_attachment.this_linux,
+#     azurerm_virtual_machine_data_disk_attachment.this_windows
+#   ]
+# }
 
 resource "azapi_resource" "this_maintenance_configuration_assignment" {
   for_each = var.maintenance_configuration_resource_ids


### PR DESCRIPTION
## Description

The AVM lint toolchain resolves tool versions dynamically rather than pinning them. It has floated to a newer set (`conftest` 0.68.2 → 0.69.0, `mapotf` 0.1.8 → 0.1.9, `terraform-docs` 0.20.0 → 0.24.0), and the accompanying ruleset enables tflint's `terraform_comment_syntax` rule.

Nineteen pre-existing `/* ... */` block comments now emit warnings, and because `avm lint` fails at the **warning** threshold, this **blocks every pull request in the repository** — not just new ones. It is unrelated to the content of any PR; #387 hit it immediately after a rebase onto current `main`.

This converts each block comment to `#` line comments.

## Trade-offs

**Nothing is uncommented, added or removed.** Every line inside the blocks is preserved verbatim, including indentation — only the delimiter style changes:

```diff
-/* Uncomment this section if you would like to include a bastion resource with this example.
-resource "azurerm_public_ip" "bastionpip" {
-  name = module.naming.public_ip.name_unique
-}
-*/
+# Uncomment this section if you would like to include a bastion resource with this example.
+# resource "azurerm_public_ip" "bastionpip" {
+#   name = module.naming.public_ip.name_unique
+# }
```

The diff looks larger than it is: 19 `.tf` files carry the change, and the other 17 files are example `README.md`s that pre-commit regenerates because they embed the example sources.

Two `/*` strings remain in `main.tf`, inside an outer `#` comment. They are comment *text*, not comment syntax, and tflint does not flag them. Left alone to keep the diff minimal.

## Test results

| Check | Result |
|---|---|
| `avm lint` | **pass** (was 19 warnings → fail) |
| `avm pre-commit` | **pass**, example READMEs regenerated |
| `avm test unit` | **31 runs, 31 passed, 0 failed** |

Verified no functional change: every removed line reappears identically with a `#` prefix, and no `resource`, `module`, `variable` or `output` block was touched.

## Type of Change

- [x] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

> [!NOTE]
> #387 is blocked on this. Its own lint errors are already resolved and 24 of 25 CI jobs pass — including all 21 e2e examples — with only this rule failing.
