### PR TITLE
feat: migrate the network interface and public IP to azapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,19 +112,14 @@ The following resources are used by this module:
 - [azapi_resource.this_virtual_machine_diagnostic_settings](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
 - [azapi_resource.this_virtual_machine_role_assignments](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
 - [azapi_resource.this_windows_virtualmachine_lock](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
+- [azapi_resource.virtualmachine_network_interfaces](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
+- [azapi_resource.virtualmachine_public_ips](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
 - [azapi_update_resource.this_os_disk_network_access](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/update_resource) (resource)
 - [azurerm_dev_test_global_vm_shutdown_schedule.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dev_test_global_vm_shutdown_schedule) (resource)
 - [azurerm_key_vault_secret.admin_password](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) (resource)
 - [azurerm_key_vault_secret.admin_ssh_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) (resource)
 - [azurerm_linux_virtual_machine.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_virtual_machine) (resource)
 - [azurerm_managed_disk.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/managed_disk) (resource)
-- [azurerm_network_interface.virtualmachine_network_interfaces](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_interface) (resource)
-- [azurerm_network_interface_application_gateway_backend_address_pool_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_interface_application_gateway_backend_address_pool_association) (resource)
-- [azurerm_network_interface_application_security_group_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_interface_application_security_group_association) (resource)
-- [azurerm_network_interface_backend_address_pool_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_interface_backend_address_pool_association) (resource)
-- [azurerm_network_interface_nat_rule_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_interface_nat_rule_association) (resource)
-- [azurerm_network_interface_security_group_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_interface_security_group_association) (resource)
-- [azurerm_public_ip.virtualmachine_public_ips](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) (resource)
 - [azurerm_virtual_machine_data_disk_attachment.this_linux](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_machine_data_disk_attachment) (resource)
 - [azurerm_virtual_machine_data_disk_attachment.this_linux_existing](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_machine_data_disk_attachment) (resource)
 - [azurerm_virtual_machine_data_disk_attachment.this_windows](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_machine_data_disk_attachment) (resource)
@@ -934,6 +929,8 @@ apply.
 - `authorization_locks` - Ignored body paths for the management locks.
 - `authorization_role_assignments` - Ignored body paths for the role assignments.
 - `insights_diagnostic_settings` - Ignored body paths for the diagnostic settings.
+- `network_network_interfaces` - Ignored body paths for the network interfaces.
+- `network_public_ip_addresses` - Ignored body paths for the public IP addresses.
 - `recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems` - Paths passed to the backup submodule.
 - `recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems.recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems` - Ignored body paths for the backup protected item.
 
@@ -945,6 +942,8 @@ object({
     authorization_locks                   = optional(list(string), [])
     authorization_role_assignments        = optional(list(string), [])
     insights_diagnostic_settings          = optional(list(string), [])
+    network_network_interfaces            = optional(list(string), [])
+    network_public_ip_addresses           = optional(list(string), [])
 
     recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems = optional(object({
       recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems = optional(list(string), [])
@@ -1110,7 +1109,7 @@ Description: A map of objects representing each network virtual machine network 
       - `principal_type`                             = (Optional) - The type of the `principal_id`. Possible values are `User`, `Group` and `ServicePrincipal`. It is necessary to explicitly set this attribute when creating role assignments if the principal creating the assignment is constrained by ABAC rules that filters on the PrincipalType attribute.
   - `tags`                           = (Optional) - A mapping of tags to assign to the resource.
 
-> Note: There is no per network interface `delete_option` input because the `azurerm` provider does not expose `networkProfile.networkInterfaces[].deleteOption`; `network_interface_ids` on the virtual machine resource is a plain list of IDs. This module creates each network interface as its own `azurerm_network_interface` resource, so `terraform destroy` deletes them along with the virtual machine and they are not orphaned. That setting only affects deletions performed outside Terraform.
+> Note: There is no per network interface `delete_option` input because the `azurerm` provider does not expose `networkProfile.networkInterfaces[].deleteOption`; `network_interface_ids` on the virtual machine resource is a plain list of IDs. This module creates each network interface as its own `azapi_resource` resource, so `terraform destroy` deletes them along with the virtual machine and they are not orphaned. That setting only affects deletions performed outside Terraform.
 
 Example Inputs:
 
@@ -1401,6 +1400,29 @@ Type: `string`
 
 Default: `"Windows"`
 
+### <a name="input_parent_id"></a> [parent\_id](#input\_parent\_id)
+
+Description: The fully-qualified ARM resource ID of the resource group the network interfaces and public IP  
+addresses are deployed into, for example
+`/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}`.
+
+When omitted, the subscription is derived from the first `private_ip_subnet_resource_id` supplied  
+on any IP configuration. Azure requires a network interface and its subnet to share a subscription,  
+so the derived value is correct wherever a subnet is supplied. The resource group name continues to  
+come from `resource_group_name`, or from a network interface's own `resource_group_name`.
+
+This value **must be known at plan time**. An unknown value causes AzAPI to replace the resource  
+rather than update it in place, which for an existing network interface means a destroy and  
+recreate. Deriving from the subnet is only unknown while that subnet is itself being created or  
+replaced. Set this input explicitly if you ever replace the subnet underneath an existing virtual  
+machine, so the interface is not dragged into the replacement.
+
+At least one of `parent_id` or a `private_ip_subnet_resource_id` must be supplied.
+
+Type: `string`
+
+Default: `null`
+
 ### <a name="input_patch_assessment_mode"></a> [patch\_assessment\_mode](#input\_patch\_assessment\_mode)
 
 Description: (Optional) Specifies the mode of VM Guest Patching for the Virtual Machine. Possible values are `AutomaticByPlatform` or `ImageDefault`. Defaults to `ImageDefault`.
@@ -1561,6 +1583,8 @@ sovereign cloud with older API versions, or when opting into a newer preview API
 - `authorization_locks` - Management locks applied to the virtual machine and its child resources.
 - `authorization_role_assignments` - Role assignments applied to the virtual machine and its child resources.
 - `insights_diagnostic_settings` - Diagnostic settings applied to the virtual machine and its OS disk.
+- `network_network_interfaces` - The network interfaces created for the virtual machine.
+- `network_public_ip_addresses` - The public IP addresses created for the virtual machine's IP configurations.
 - `recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems` - Resource-type overrides passed to the backup submodule.
 - `recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems.recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems` - The backup protected item.
 
@@ -1573,6 +1597,8 @@ object({
     authorization_locks                   = optional(string, "Microsoft.Authorization/locks@2020-05-01")
     authorization_role_assignments        = optional(string, "Microsoft.Authorization/roleAssignments@2022-04-01")
     insights_diagnostic_settings          = optional(string, "Microsoft.Insights/diagnosticSettings@2021-05-01-preview")
+    network_network_interfaces            = optional(string, "Microsoft.Network/networkInterfaces@2024-10-01")
+    network_public_ip_addresses           = optional(string, "Microsoft.Network/publicIPAddresses@2024-10-01")
 
     recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems = optional(object({
       recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems = optional(string)
@@ -2200,11 +2226,19 @@ Description: The name used for the virtual machines name.
 
 ### <a name="output_network_interfaces"></a> [network\_interfaces](#output\_network\_interfaces)
 
-Description: The full ARM object map associated with the deployed network interface(s). Exporting this in the event that a nic property not exposed as part of the azurerm vm export is required.
+Description: The map of deployed network interface(s), keyed as supplied to `network_interfaces`. The attribute names are preserved from the `azurerm` provider so existing expressions keep working after the AzAPI migration. Server-populated values such as `mac_address` and `private_ip_address` are only available after apply. For the unshaped ARM representation use `network_interfaces_azapi`.
+
+### <a name="output_network_interfaces_azapi"></a> [network\_interfaces\_azapi](#output\_network\_interfaces\_azapi)
+
+Description: The full AzAPI object map for the deployed network interface(s). Attribute names follow the ARM schema, and the interface associations appear as properties of the interface body. Use this when a property is required that `network_interfaces` does not expose.
 
 ### <a name="output_public_ips"></a> [public\_ips](#output\_public\_ips)
 
-Description: The full ARM object map associated with any deployed public ip(s). Exporting this in the event that a public ip property not exposed as part of the azurerm vm export is required.
+Description: The map of deployed public ip(s), keyed by `<network interface key>-<ip configuration key>`. The attribute names are preserved from the `azurerm` provider so existing expressions keep working after the AzAPI migration. Server-populated values such as `ip_address` and `fqdn` are only available after apply. For the unshaped ARM representation use `public_ips_azapi`.
+
+### <a name="output_public_ips_azapi"></a> [public\_ips\_azapi](#output\_public\_ips\_azapi)
+
+Description: The full AzAPI object map for any deployed public ip(s). Attribute names follow the ARM schema. Use this when a property is required that `public_ips` does not expose.
 
 ### <a name="output_resource"></a> [resource](#output\_resource)
 

--- a/locals.networking.tf
+++ b/locals.networking.tf
@@ -1,0 +1,209 @@
+locals {
+  # D1 (G15): parent_id MUST be known at plan time. Composing it from a data source makes it
+  # "(known after apply)", which forces replacement of an existing interface — a destructive
+  # migration. The subscription is therefore taken from var.parent_id when supplied, and otherwise
+  # derived from a subnet resource ID the caller already passed in. Azure requires a network
+  # interface and its subnet to live in the same subscription, so the derived value is correct by
+  # construction rather than by assumption.
+  nic_subnet_resource_ids = flatten([
+    for nk, nv in var.network_interfaces : [
+      for ipck, ipcv in nv.ip_configurations :
+      ipcv.private_ip_subnet_resource_id if ipcv.private_ip_subnet_resource_id != null
+    ]
+  ])
+  derived_subscription_id = length(local.nic_subnet_resource_ids) > 0 ? split("/", local.nic_subnet_resource_ids[0])[2] : null
+  subscription_id         = var.parent_id != null ? split("/", var.parent_id)[2] : local.derived_subscription_id
+  # Resolved defensively: when the subscription cannot be established the value stays null so the
+  # resource preconditions report the problem instead of a template interpolation error.
+  nic_parent_ids = {
+    for nk, nv in var.network_interfaces :
+    nk => nv.resource_group_name == null && var.parent_id != null ? var.parent_id : (
+      local.subscription_id == null ? null :
+      "/subscriptions/${local.subscription_id}/resourceGroups/${coalesce(nv.resource_group_name, var.resource_group_name)}"
+    )
+  }
+  public_ip_parent_id = var.parent_id != null ? var.parent_id : (
+    local.subscription_id == null ? null :
+    "/subscriptions/${local.subscription_id}/resourceGroups/${var.resource_group_name}"
+  )
+
+  # D4: ARM models the network security group as a single reference on the interface, not a
+  # collection, so at most one entry of the map can ever apply. A precondition rejects more than
+  # one rather than silently discarding the rest.
+  nic_network_security_group = {
+    for nk, nv in var.network_interfaces :
+    nk => length(nv.network_security_groups) == 0 ? null : {
+      id = values(nv.network_security_groups)[0].network_security_group_resource_id
+    }
+  }
+  # ARM scopes application security groups to each IP configuration, while the azurerm association
+  # resource scoped them to the whole interface. Replicating the interface-level map onto every IP
+  # configuration preserves the previous behaviour.
+  nic_application_security_groups = {
+    for nk, nv in var.network_interfaces :
+    nk => [for ask, asv in nv.application_security_groups : { id = asv.application_security_group_resource_id }]
+  }
+  nic_public_ip_ids = {
+    for key, values in local.nics_ip_configs :
+    key => values.ipconfig.create_public_ip_address ? azapi_resource.virtualmachine_public_ips[key].id : values.ipconfig.public_ip_address_resource_id
+  }
+  nic_ip_configurations = {
+    for nk, nv in var.network_interfaces :
+    nk => [
+      for ipck, ipcv in nv.ip_configurations : {
+        name = ipcv.name
+        properties = merge(
+          {
+            primary                   = ipcv.is_primary_ipconfiguration
+            privateIPAddressVersion   = ipcv.private_ip_address_version
+            privateIPAllocationMethod = ipcv.private_ip_address_allocation
+          },
+          ipcv.private_ip_address == null ? {} : { privateIPAddress = ipcv.private_ip_address },
+          ipcv.private_ip_subnet_resource_id == null ? {} : { subnet = { id = ipcv.private_ip_subnet_resource_id } },
+          ipcv.gateway_load_balancer_frontend_ip_configuration_resource_id == null ? {} : {
+            gatewayLoadBalancer = { id = ipcv.gateway_load_balancer_frontend_ip_configuration_resource_id }
+          },
+          local.nic_public_ip_ids["${nk}-${ipck}"] == null ? {} : {
+            publicIPAddress = { id = local.nic_public_ip_ids["${nk}-${ipck}"] }
+          },
+          length(local.nic_application_security_groups[nk]) == 0 ? {} : {
+            applicationSecurityGroups = local.nic_application_security_groups[nk]
+          },
+          length(ipcv.load_balancer_backend_pools) == 0 ? {} : {
+            loadBalancerBackendAddressPools = [
+              for lbk, lbv in ipcv.load_balancer_backend_pools : { id = lbv.load_balancer_backend_pool_resource_id }
+            ]
+          },
+          length(ipcv.app_gateway_backend_pools) == 0 ? {} : {
+            applicationGatewayBackendAddressPools = [
+              for agk, agv in ipcv.app_gateway_backend_pools : { id = agv.app_gateway_backend_pool_resource_id }
+            ]
+          },
+          length(ipcv.load_balancer_nat_rules) == 0 ? {} : {
+            loadBalancerInboundNatRules = [
+              for lbk, lbv in ipcv.load_balancer_nat_rules : { id = lbv.load_balancer_nat_rule_resource_id }
+            ]
+          },
+        )
+      }
+    ]
+  }
+  nic_dns_settings = {
+    for nk, nv in var.network_interfaces :
+    nk => nv.dns_servers == null && nv.internal_dns_name_label == null ? null : merge(
+      nv.dns_servers == null ? {} : { dnsServers = nv.dns_servers },
+      nv.internal_dns_name_label == null ? {} : { internalDnsNameLabel = nv.internal_dns_name_label },
+    )
+  }
+  nic_bodies = {
+    for nk, nv in var.network_interfaces :
+    nk => merge(
+      {
+        properties = merge(
+          {
+            enableAcceleratedNetworking = nv.accelerated_networking_enabled
+            enableIPForwarding          = nv.ip_forwarding_enabled
+            ipConfigurations            = local.nic_ip_configurations[nk]
+          },
+          local.nic_dns_settings[nk] == null ? {} : { dnsSettings = local.nic_dns_settings[nk] },
+          local.nic_network_security_group[nk] == null ? {} : { networkSecurityGroup = local.nic_network_security_group[nk] },
+        )
+      },
+      var.edge_zone == null ? {} : { extendedLocation = { name = var.edge_zone, type = "EdgeZone" } },
+    )
+  }
+
+  public_ip_ddos_settings = var.public_ip_configuration_details.ddos_protection_mode == null ? null : merge(
+    { protectionMode = var.public_ip_configuration_details.ddos_protection_mode },
+    var.public_ip_configuration_details.ddos_protection_plan_id == null ? {} : {
+      ddosProtectionPlan = { id = var.public_ip_configuration_details.ddos_protection_plan_id }
+    },
+  )
+  public_ip_body = merge(
+    {
+      properties = merge(
+        {
+          publicIPAllocationMethod = var.public_ip_configuration_details.allocation_method
+          publicIPAddressVersion   = var.public_ip_configuration_details.ip_version
+          idleTimeoutInMinutes     = var.public_ip_configuration_details.idle_timeout_in_minutes
+        },
+        var.public_ip_configuration_details.domain_name_label == null ? {} : {
+          dnsSettings = { domainNameLabel = var.public_ip_configuration_details.domain_name_label }
+        },
+        local.public_ip_ddos_settings == null ? {} : { ddosSettings = local.public_ip_ddos_settings },
+      )
+      sku = {
+        name = var.public_ip_configuration_details.sku
+        tier = var.public_ip_configuration_details.sku_tier
+      }
+    },
+    var.public_ip_configuration_details.zones == null ? {} : { zones = sort(tolist(var.public_ip_configuration_details.zones)) },
+    var.edge_zone == null ? {} : { extendedLocation = { name = var.edge_zone, type = "EdgeZone" } },
+  )
+}
+
+# D2: the AzAPI resources expose the ARM schema, which is not what consumers of this module have
+# been reading. These locals reshape each resource back into the attribute names the azurerm
+# resources exported so existing expressions keep working. The unshaped objects remain available
+# through the *_azapi outputs.
+locals {
+  network_interfaces_output = {
+    for nk, nic in azapi_resource.virtualmachine_network_interfaces : nk => {
+      id                             = nic.id
+      name                           = nic.name
+      location                       = nic.location
+      resource_group_name            = coalesce(var.network_interfaces[nk].resource_group_name, var.resource_group_name)
+      tags                           = nic.tags
+      accelerated_networking_enabled = var.network_interfaces[nk].accelerated_networking_enabled
+      ip_forwarding_enabled          = var.network_interfaces[nk].ip_forwarding_enabled
+      dns_servers                    = var.network_interfaces[nk].dns_servers
+      internal_dns_name_label        = var.network_interfaces[nk].internal_dns_name_label
+      mac_address                    = try(nic.output.properties.macAddress, null)
+      virtual_machine_id             = try(nic.output.properties.virtualMachine.id, null)
+      applied_dns_servers            = try(nic.output.properties.dnsSettings.appliedDnsServers, [])
+      internal_domain_name_suffix    = try(nic.output.properties.dnsSettings.internalDomainNameSuffix, null)
+      private_ip_address = try([
+        for config in nic.output.properties.ipConfigurations :
+        config.properties.privateIPAddress if try(config.properties.primary, false)
+      ][0], null)
+      private_ip_addresses = try([
+        for config in nic.output.properties.ipConfigurations :
+        config.properties.privateIPAddress
+      ], [])
+      ip_configuration = try([
+        for config in nic.output.properties.ipConfigurations : {
+          name                          = config.name
+          primary                       = try(config.properties.primary, null)
+          private_ip_address            = try(config.properties.privateIPAddress, null)
+          private_ip_address_allocation = try(config.properties.privateIPAllocationMethod, null)
+          private_ip_address_version    = try(config.properties.privateIPAddressVersion, null)
+          subnet_id                     = try(config.properties.subnet.id, null)
+          public_ip_address_id          = try(config.properties.publicIPAddress.id, null)
+          gateway_load_balancer_frontend_ip_configuration_id = try(
+            config.properties.gatewayLoadBalancer.id, null
+          )
+        }
+      ], [])
+    }
+  }
+  public_ips_output = {
+    for key, pip in azapi_resource.virtualmachine_public_ips : key => {
+      id                      = pip.id
+      name                    = pip.name
+      location                = pip.location
+      resource_group_name     = var.resource_group_name
+      tags                    = pip.tags
+      allocation_method       = var.public_ip_configuration_details.allocation_method
+      ddos_protection_mode    = var.public_ip_configuration_details.ddos_protection_mode
+      ddos_protection_plan_id = var.public_ip_configuration_details.ddos_protection_plan_id
+      domain_name_label       = var.public_ip_configuration_details.domain_name_label
+      idle_timeout_in_minutes = var.public_ip_configuration_details.idle_timeout_in_minutes
+      ip_version              = var.public_ip_configuration_details.ip_version
+      sku                     = var.public_ip_configuration_details.sku
+      sku_tier                = var.public_ip_configuration_details.sku_tier
+      zones                   = var.public_ip_configuration_details.zones
+      ip_address              = try(pip.output.properties.ipAddress, null)
+      fqdn                    = try(pip.output.properties.dnsSettings.fqdn, null)
+    }
+  }
+}

--- a/locals.tf
+++ b/locals.tf
@@ -24,16 +24,6 @@ locals {
   } : null
   #set the type value for the managed identity that is used by azurerm
   managed_identity_type = var.managed_identities.system_assigned ? ((length(var.managed_identities.user_assigned_resource_ids) > 0) ? "SystemAssigned, UserAssigned" : "SystemAssigned") : ((length(var.managed_identities.user_assigned_resource_ids) > 0) ? "UserAssigned" : null)
-  #flatten the ASG's for the nics
-  nics_asgs = { for asg in flatten([
-    for nk, nv in var.network_interfaces : [
-      for ask, asv in nv.application_security_groups : {
-        nic_key                     = nk
-        asg_key                     = ask
-        application_security_groups = asv
-      }
-    ]
-  ]) : "${asg.nic_key}-${asg.asg_key}" => asg }
   #flatten the diag settings for the nics
   nics_diag_settings = { for ds in flatten([
     for nk, nv in var.network_interfaces : [
@@ -54,58 +44,6 @@ locals {
       }
     ]
   ]) : "${ip_config.nic_key}-${ip_config.ipconfig_key}" => ip_config }
-  #flatten the ip_configs for the nics and app gateway pools
-  nics_ip_configs_app_gw_pools = { for ag_pool in flatten([
-    for nk, nv in var.network_interfaces : [
-      for ipck, ipcv in nv.ip_configurations : [
-        for agk, agv in ipcv.app_gateway_backend_pools : {
-          nic_key       = nk
-          ipconfig_key  = ipck
-          ipconfig_name = ipcv.name
-          ag_key        = agk
-          ag_pools      = agv
-        }
-      ]
-    ]
-  ]) : "${ag_pool.nic_key}-${ag_pool.ipconfig_key}-${ag_pool.ag_key}" => ag_pool }
-  #flatten the ip_configs for the nics and load-balancer nat rules
-  nics_ip_configs_lb_nat_rules = { for lb_nat_rule in flatten([
-    for nk, nv in var.network_interfaces : [
-      for ipck, ipcv in nv.ip_configurations : [
-        for lbk, lbv in ipcv.load_balancer_nat_rules : {
-          nic_key       = nk
-          ipconfig_key  = ipck
-          ipconfig_name = ipcv.name
-          lb_key        = lbk
-          lb_nat_rules  = lbv
-        }
-      ]
-    ]
-  ]) : "${lb_nat_rule.nic_key}-${lb_nat_rule.ipconfig_key}-${lb_nat_rule.lb_key}" => lb_nat_rule }
-  #flatten the ip_configs for the nics and load-balancer pools
-  nics_ip_configs_lb_pools = { for lb_pool in flatten([
-    for nk, nv in var.network_interfaces : [
-      for ipck, ipcv in nv.ip_configurations : [
-        for lbk, lbv in ipcv.load_balancer_backend_pools : {
-          nic_key       = nk
-          ipconfig_key  = ipck
-          ipconfig_name = ipcv.name
-          lb_key        = lbk
-          lb_pools      = lbv
-        }
-      ]
-    ]
-  ]) : "${lb_pool.nic_key}-${lb_pool.ipconfig_key}-${lb_pool.lb_key}" => lb_pool }
-  #flatten the NSG's for the nics
-  nics_nsgs = { for nsg in flatten([
-    for nk, nv in var.network_interfaces : [
-      for nsk, nsv in nv.network_security_groups : {
-        nic_key                 = nk
-        nsg_key                 = nsk
-        network_security_groups = nsv
-      }
-    ]
-  ]) : "${nsg.nic_key}-${nsg.nsg_key}" => nsg }
   #flatten the role assignments for the nics
   nics_role_assignments = { for ra in flatten([
     for nk, nv in var.network_interfaces : [

--- a/main.linux_vm.tf
+++ b/main.linux_vm.tf
@@ -3,8 +3,8 @@ resource "azurerm_linux_virtual_machine" "this" {
 
   location = var.location
   name     = var.name
-  #network_interface_ids = [for interface in azurerm_network_interface.virtualmachine_network_interfaces : interface.id]
-  network_interface_ids = [for interface in local.ordered_network_interface_keys : azurerm_network_interface.virtualmachine_network_interfaces[interface].id]
+  #network_interface_ids = [for interface in azapi_resource.virtualmachine_network_interfaces : interface.id]
+  network_interface_ids = [for interface in local.ordered_network_interface_keys : azapi_resource.virtualmachine_network_interfaces[interface].id]
   resource_group_name   = var.resource_group_name
   size                  = var.sku_size
   #optional properties
@@ -168,13 +168,8 @@ resource "azurerm_linux_virtual_machine" "this" {
       error_message = "The os_managed_disk_id and os_disk.diff_disk_settings are mutually exclusive. Ephemeral OS disks cannot be used when attaching an existing managed disk."
     }
   }
-  depends_on = [ #set explicit depends on for each association to address delete order issues.
-    azurerm_network_interface.virtualmachine_network_interfaces,
-    azurerm_network_interface_security_group_association.this,
-    azurerm_network_interface_application_security_group_association.this,
-    azurerm_network_interface_backend_address_pool_association.this,
-    azurerm_network_interface_application_gateway_backend_address_pool_association.this,
-    azurerm_network_interface_nat_rule_association.this
+  depends_on = [ #the associations are now properties of the interface body, so the interface alone is enough.
+    azapi_resource.virtualmachine_network_interfaces
   ]
 }
 
@@ -223,8 +218,8 @@ resource "azapi_resource" "this_linux_virtualmachine_lock" {
 
   depends_on = [
     azurerm_managed_disk.this,
-    azurerm_network_interface.virtualmachine_network_interfaces,
-    azurerm_public_ip.virtualmachine_public_ips,
+    azapi_resource.virtualmachine_network_interfaces,
+    azapi_resource.virtualmachine_public_ips,
     azapi_resource.system_managed_identity_role_assignments,
     azurerm_virtual_machine_data_disk_attachment.this_linux,
     azurerm_virtual_machine_data_disk_attachment.this_windows,

--- a/main.networking.tf
+++ b/main.networking.tf
@@ -1,49 +1,89 @@
+moved {
+  from = azurerm_public_ip.virtualmachine_public_ips
+  to   = azapi_resource.virtualmachine_public_ips
+}
+
 #create public ip(s) - Assumes each ip configuration has a unique name
-resource "azurerm_public_ip" "virtualmachine_public_ips" {
+resource "azapi_resource" "virtualmachine_public_ips" {
   for_each = { for key, values in local.nics_ip_configs : key => values if values.ipconfig.create_public_ip_address == true }
 
-  allocation_method       = var.public_ip_configuration_details.allocation_method
-  location                = var.location
-  name                    = each.value.ipconfig.public_ip_address_name
-  resource_group_name     = var.resource_group_name
-  ddos_protection_mode    = var.public_ip_configuration_details.ddos_protection_mode
-  ddos_protection_plan_id = var.public_ip_configuration_details.ddos_protection_plan_id
-  domain_name_label       = var.public_ip_configuration_details.domain_name_label
-  edge_zone               = var.edge_zone #var.public_ip_configuration_details.edge_zone
-  idle_timeout_in_minutes = var.public_ip_configuration_details.idle_timeout_in_minutes
-  ip_version              = var.public_ip_configuration_details.ip_version
-  sku                     = var.public_ip_configuration_details.sku
-  sku_tier                = var.public_ip_configuration_details.sku_tier
-  tags                    = var.public_ip_configuration_details.tags != null && var.public_ip_configuration_details != {} ? var.public_ip_configuration_details.tags : local.tags
-  zones                   = var.public_ip_configuration_details.zones #var.zone != null ? [var.zone] : [] #
+  location               = var.location
+  name                   = each.value.ipconfig.public_ip_address_name
+  parent_id              = local.public_ip_parent_id
+  type                   = var.resource_types.network_public_ip_addresses
+  body                   = local.public_ip_body
+  create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_body_changes    = length(var.ignore_body_changes.network_public_ip_addresses) > 0 ? var.ignore_body_changes.network_public_ip_addresses : null
+  read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  replace_triggers_refs  = []
+  response_export_values = ["properties.ipAddress", "properties.dnsSettings"]
+  retry                  = var.retry
+  tags                   = var.public_ip_configuration_details.tags != null ? var.public_ip_configuration_details.tags : local.tags
+  update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
+
+  lifecycle {
+    precondition {
+      condition     = local.public_ip_parent_id != null
+      error_message = "Unable to determine the subscription for the public IP address. Set `parent_id` to the resource group resource ID, or supply `private_ip_subnet_resource_id` on at least one IP configuration so the subscription can be derived from it."
+    }
+  }
+}
+
+moved {
+  from = azurerm_network_interface.virtualmachine_network_interfaces
+  to   = azapi_resource.virtualmachine_network_interfaces
 }
 
 #create the Nics
-resource "azurerm_network_interface" "virtualmachine_network_interfaces" {
+resource "azapi_resource" "virtualmachine_network_interfaces" {
   for_each = var.network_interfaces
 
-  location                       = var.location
-  name                           = each.value.name
-  resource_group_name            = coalesce(each.value.resource_group_name, var.resource_group_name)
-  accelerated_networking_enabled = each.value.accelerated_networking_enabled
-  dns_servers                    = each.value.dns_servers
-  edge_zone                      = var.edge_zone #each.value.edge_zone
-  internal_dns_name_label        = each.value.internal_dns_name_label
-  ip_forwarding_enabled          = each.value.ip_forwarding_enabled
-  tags                           = each.value.tags != null && each.value.tags != {} ? each.value.tags : local.tags
+  location               = var.location
+  name                   = each.value.name
+  parent_id              = local.nic_parent_ids[each.key]
+  type                   = var.resource_types.network_network_interfaces
+  body                   = local.nic_bodies[each.key]
+  create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_body_changes    = length(var.ignore_body_changes.network_network_interfaces) > 0 ? var.ignore_body_changes.network_network_interfaces : null
+  read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  replace_triggers_refs  = []
+  response_export_values = ["properties.ipConfigurations", "properties.macAddress", "properties.virtualMachine", "properties.dnsSettings"]
+  retry                  = var.retry
+  tags                   = each.value.tags != null && each.value.tags != {} ? each.value.tags : local.tags
+  update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
 
-  dynamic "ip_configuration" {
-    for_each = each.value.ip_configurations
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
 
     content {
-      name                                               = ip_configuration.value.name
-      private_ip_address_allocation                      = ip_configuration.value.private_ip_address_allocation
-      gateway_load_balancer_frontend_ip_configuration_id = ip_configuration.value.gateway_load_balancer_frontend_ip_configuration_resource_id
-      primary                                            = ip_configuration.value.is_primary_ipconfiguration
-      private_ip_address                                 = ip_configuration.value.private_ip_address
-      private_ip_address_version                         = ip_configuration.value.private_ip_address_version
-      public_ip_address_id                               = ip_configuration.value.create_public_ip_address ? azurerm_public_ip.virtualmachine_public_ips["${each.key}-${ip_configuration.key}"].id : ip_configuration.value.public_ip_address_resource_id
-      subnet_id                                          = ip_configuration.value.private_ip_subnet_resource_id
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
+
+  lifecycle {
+    precondition {
+      condition     = local.nic_parent_ids[each.key] != null
+      error_message = "Unable to determine the subscription for network interface '${each.key}'. Set `parent_id` to the resource group resource ID, or supply `private_ip_subnet_resource_id` on at least one IP configuration so the subscription can be derived from it."
+    }
+    precondition {
+      condition     = length(each.value.network_security_groups) <= 1
+      error_message = "Network interface '${each.key}' declares ${length(each.value.network_security_groups)} network security groups. ARM attaches at most one network security group to an interface, so only a single entry is supported."
     }
   }
 }
@@ -58,7 +98,7 @@ resource "azapi_resource" "this_public_ip_lock" {
   for_each = { for key, values in local.nics_ip_configs : key => values if((values.ipconfig.create_public_ip_address == true) && (var.public_ip_configuration_details.lock_level != null)) }
 
   name      = coalesce(each.value.ipconfig.public_ip_address_lock_name, "${each.key}-lock")
-  parent_id = azurerm_public_ip.virtualmachine_public_ips[each.key].id
+  parent_id = azapi_resource.virtualmachine_public_ips[each.key].id
   type      = var.resource_types.authorization_locks
   body = {
     properties = {
@@ -86,8 +126,8 @@ resource "azapi_resource" "this_public_ip_lock" {
   }
 
   depends_on = [
-    azurerm_network_interface.virtualmachine_network_interfaces,
-    azurerm_public_ip.virtualmachine_public_ips,
+    azapi_resource.virtualmachine_network_interfaces,
+    azapi_resource.virtualmachine_public_ips,
     azurerm_linux_virtual_machine.this,
     azurerm_windows_virtual_machine.this
   ]
@@ -103,7 +143,7 @@ resource "azapi_resource" "this_nic_lock" {
   for_each = { for nic, nicvalues in var.network_interfaces : nic => nicvalues if nicvalues.lock_level != null }
 
   name      = coalesce(each.value.lock_name, "${each.key}-lock")
-  parent_id = azurerm_network_interface.virtualmachine_network_interfaces[each.key].id
+  parent_id = azapi_resource.virtualmachine_network_interfaces[each.key].id
   type      = var.resource_types.authorization_locks
   body = {
     properties = {
@@ -131,8 +171,8 @@ resource "azapi_resource" "this_nic_lock" {
   }
 
   depends_on = [
-    azurerm_network_interface.virtualmachine_network_interfaces,
-    azurerm_public_ip.virtualmachine_public_ips,
+    azapi_resource.virtualmachine_network_interfaces,
+    azapi_resource.virtualmachine_public_ips,
     azurerm_linux_virtual_machine.this,
     azurerm_windows_virtual_machine.this
   ]
@@ -148,7 +188,7 @@ resource "azapi_resource" "this_network_interface_role_assignments" {
   for_each = local.nics_role_assignments
 
   name                 = module.avm_utl_interfaces.role_assignments_azapi["nic-${each.key}"].name
-  parent_id            = azurerm_network_interface.virtualmachine_network_interfaces[each.value.nic_key].id
+  parent_id            = azapi_resource.virtualmachine_network_interfaces[each.value.nic_key].id
   type                 = var.resource_types.authorization_role_assignments
   body                 = module.avm_utl_interfaces.role_assignments_azapi["nic-${each.key}"].body
   create_headers       = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
@@ -191,7 +231,7 @@ resource "azapi_resource" "this_network_interface_diagnostic_settings" {
   for_each = local.nics_diag_settings
 
   name                   = each.value.diagnostic_setting.name
-  parent_id              = azurerm_network_interface.virtualmachine_network_interfaces[each.value.nic_key].id
+  parent_id              = azapi_resource.virtualmachine_network_interfaces[each.value.nic_key].id
   type                   = var.resource_types.insights_diagnostic_settings
   body                   = local.interface_diagnostic_settings_nic[each.key]
   create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
@@ -216,64 +256,49 @@ resource "azapi_resource" "this_network_interface_diagnostic_settings" {
   }
 }
 
-#create the nic associations
-### NSG associations
-resource "azurerm_network_interface_security_group_association" "this" {
-  for_each = local.nics_nsgs
+# ARM has no standalone association resources. Every association below is a property of the network
+# interface (or of one of its IP configurations) and is now assembled into the interface body by
+# local.nic_bodies. Forget the previous state entries without issuing a remote delete: the interface
+# itself keeps its state through the `moved` block above, so the underlying Azure configuration is
+# unchanged and only Terraform's model of it differs.
+#
+# The map keys are user-defined, so keyed `moved` blocks cannot be generated for these addresses.
+removed {
+  from = azurerm_network_interface_security_group_association.this
 
-  network_interface_id      = azurerm_network_interface.virtualmachine_network_interfaces[each.value.nic_key].id
-  network_security_group_id = each.value.network_security_groups.network_security_group_resource_id
-}
-
-### ASG Associations
-resource "azurerm_network_interface_application_security_group_association" "this" {
-  for_each = local.nics_asgs
-
-  application_security_group_id = each.value.application_security_groups.application_security_group_resource_id
-  network_interface_id          = azurerm_network_interface.virtualmachine_network_interfaces[each.value.nic_key].id
-
-  depends_on = [azurerm_network_interface_security_group_association.this]
-}
-
-### LB Pool Association
-resource "azurerm_network_interface_backend_address_pool_association" "this" {
-  for_each = local.nics_ip_configs_lb_pools
-
-  backend_address_pool_id = each.value.lb_pools.load_balancer_backend_pool_resource_id
-  ip_configuration_name   = each.value.ipconfig_name
-  network_interface_id    = azurerm_network_interface.virtualmachine_network_interfaces[each.value.nic_key].id
-
-  depends_on = [azurerm_network_interface_security_group_association.this,
-  azurerm_network_interface_application_security_group_association.this]
-}
-
-### App GW Assocation
-resource "azurerm_network_interface_application_gateway_backend_address_pool_association" "this" {
-  for_each = local.nics_ip_configs_app_gw_pools
-
-  backend_address_pool_id = each.value.ag_pools.app_gateway_backend_pool_resource_id
-  ip_configuration_name   = each.value.ipconfig_name
-  network_interface_id    = azurerm_network_interface.virtualmachine_network_interfaces[each.value.nic_key].id
-
-  timeouts {
-    delete = "60m"
+  lifecycle {
+    destroy = false
   }
-
-  depends_on = [azurerm_network_interface_security_group_association.this,
-    azurerm_network_interface_application_security_group_association.this,
-  azurerm_network_interface_backend_address_pool_association.this]
 }
 
-### NAT Rule Assocation
-resource "azurerm_network_interface_nat_rule_association" "this" {
-  for_each = local.nics_ip_configs_lb_nat_rules
+removed {
+  from = azurerm_network_interface_application_security_group_association.this
 
-  ip_configuration_name = each.value.ipconfig_name
-  nat_rule_id           = each.value.lb_nat_rules.load_balancer_nat_rule_resource_id
-  network_interface_id  = azurerm_network_interface.virtualmachine_network_interfaces[each.value.nic_key].id
+  lifecycle {
+    destroy = false
+  }
+}
 
-  depends_on = [azurerm_network_interface_security_group_association.this,
-    azurerm_network_interface_application_security_group_association.this,
-    azurerm_network_interface_backend_address_pool_association.this,
-  azurerm_network_interface_application_gateway_backend_address_pool_association.this]
+removed {
+  from = azurerm_network_interface_backend_address_pool_association.this
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = azurerm_network_interface_application_gateway_backend_address_pool_association.this
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = azurerm_network_interface_nat_rule_association.this
+
+  lifecycle {
+    destroy = false
+  }
 }

--- a/main.windows_vm.tf
+++ b/main.windows_vm.tf
@@ -3,8 +3,8 @@ resource "azurerm_windows_virtual_machine" "this" {
 
   location = var.location
   name     = var.name
-  #network_interface_ids = [for interface in azurerm_network_interface.virtualmachine_network_interfaces : interface.id]
-  network_interface_ids = [for interface in local.ordered_network_interface_keys : azurerm_network_interface.virtualmachine_network_interfaces[interface].id]
+  #network_interface_ids = [for interface in azapi_resource.virtualmachine_network_interfaces : interface.id]
+  network_interface_ids = [for interface in local.ordered_network_interface_keys : azapi_resource.virtualmachine_network_interfaces[interface].id]
   resource_group_name   = var.resource_group_name
   size                  = var.sku_size
   #required properties (admin_password and admin_username are null when using os_managed_disk_id per Provider ExactlyOneOf/ConflictsWith constraints)
@@ -187,13 +187,8 @@ resource "azurerm_windows_virtual_machine" "this" {
       error_message = "For a Windows VM the OS computer name (hostname) must be 15 characters or fewer. It is taken from `computer_name` when set, otherwise it falls back to `name`. The effective computer name here exceeds 15 characters - set `computer_name` to a value of 15 characters or fewer. (The `name` / ARM resource name itself may be up to 64 characters.)"
     }
   }
-  depends_on = [ #set explicit depends on for each association to address delete order issues.
-    azurerm_network_interface.virtualmachine_network_interfaces,
-    azurerm_network_interface_security_group_association.this,
-    azurerm_network_interface_application_security_group_association.this,
-    azurerm_network_interface_backend_address_pool_association.this,
-    azurerm_network_interface_application_gateway_backend_address_pool_association.this,
-    azurerm_network_interface_nat_rule_association.this
+  depends_on = [ #the associations are now properties of the interface body, so the interface alone is enough.
+    azapi_resource.virtualmachine_network_interfaces
   ]
 }
 
@@ -236,8 +231,8 @@ resource "azapi_resource" "this_windows_virtualmachine_lock" {
 
   depends_on = [
     azurerm_managed_disk.this,
-    azurerm_network_interface.virtualmachine_network_interfaces,
-    azurerm_public_ip.virtualmachine_public_ips,
+    azapi_resource.virtualmachine_network_interfaces,
+    azapi_resource.virtualmachine_public_ips,
     azapi_resource.system_managed_identity_role_assignments,
     azurerm_virtual_machine_data_disk_attachment.this_linux,
     azurerm_virtual_machine_data_disk_attachment.this_windows,

--- a/outputs.tf
+++ b/outputs.tf
@@ -32,13 +32,23 @@ output "name" {
 }
 
 output "network_interfaces" {
-  description = "The full ARM object map associated with the deployed network interface(s). Exporting this in the event that a nic property not exposed as part of the azurerm vm export is required."
-  value       = azurerm_network_interface.virtualmachine_network_interfaces
+  description = "The map of deployed network interface(s), keyed as supplied to `network_interfaces`. The attribute names are preserved from the `azurerm` provider so existing expressions keep working after the AzAPI migration. Server-populated values such as `mac_address` and `private_ip_address` are only available after apply. For the unshaped ARM representation use `network_interfaces_azapi`."
+  value       = local.network_interfaces_output
+}
+
+output "network_interfaces_azapi" {
+  description = "The full AzAPI object map for the deployed network interface(s). Attribute names follow the ARM schema, and the interface associations appear as properties of the interface body. Use this when a property is required that `network_interfaces` does not expose."
+  value       = azapi_resource.virtualmachine_network_interfaces
 }
 
 output "public_ips" {
-  description = "The full ARM object map associated with any deployed public ip(s). Exporting this in the event that a public ip property not exposed as part of the azurerm vm export is required."
-  value       = azurerm_public_ip.virtualmachine_public_ips
+  description = "The map of deployed public ip(s), keyed by `<network interface key>-<ip configuration key>`. The attribute names are preserved from the `azurerm` provider so existing expressions keep working after the AzAPI migration. Server-populated values such as `ip_address` and `fqdn` are only available after apply. For the unshaped ARM representation use `public_ips_azapi`."
+  value       = local.public_ips_output
+}
+
+output "public_ips_azapi" {
+  description = "The full AzAPI object map for any deployed public ip(s). Attribute names follow the ARM schema. Use this when a property is required that `public_ips` does not expose."
+  value       = azapi_resource.virtualmachine_public_ips
 }
 
 output "resource" {

--- a/tests/unit/aad_ssh_login_extension.tftest.hcl
+++ b/tests/unit/aad_ssh_login_extension.tftest.hcl
@@ -1,4 +1,13 @@
-mock_provider "azapi" {}
+mock_provider "azapi" {
+  # The virtual machine is still an azurerm resource and parses each network_interface_ids entry as
+  # an ARM ID, so the mocked interface must carry a well-formed one rather than the generated
+  # placeholder.
+  mock_resource "azapi_resource" {
+    defaults = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/networkInterfaces/nic-test"
+    }
+  }
+}
 mock_provider "azurerm" {
   mock_resource "azurerm_network_interface" {
     defaults = {

--- a/tests/unit/backup_lifecycle.tftest.hcl
+++ b/tests/unit/backup_lifecycle.tftest.hcl
@@ -1,4 +1,12 @@
 mock_provider "azapi" {
+  # The virtual machine is still an azurerm resource and parses each network_interface_ids entry as
+  # an ARM ID, so the mocked interface must carry a well-formed one rather than the generated
+  # placeholder.
+  mock_resource "azapi_resource" {
+    defaults = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/networkInterfaces/nic-test"
+    }
+  }
   mock_data "azapi_resource" {
     defaults = {
       exists = false

--- a/tests/unit/cross_subscription_app_gateway_backend_pool.tftest.hcl
+++ b/tests/unit/cross_subscription_app_gateway_backend_pool.tftest.hcl
@@ -1,4 +1,13 @@
-mock_provider "azapi" {}
+mock_provider "azapi" {
+  # The virtual machine is still an azurerm resource and parses each network_interface_ids entry as
+  # an ARM ID, so the mocked interface must carry a well-formed one rather than the generated
+  # placeholder.
+  mock_resource "azapi_resource" {
+    defaults = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/networkInterfaces/nic-test"
+    }
+  }
+}
 mock_provider "azurerm" {
   mock_resource "azurerm_network_interface" {
     defaults = {
@@ -65,11 +74,11 @@ run "application_gateway_backend_pool_can_use_another_subscription" {
   command = apply
 
   assert {
-    condition     = azurerm_network_interface_application_gateway_backend_address_pool_association.this["primary-primary-shared"].network_interface_id == "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-vm/providers/Microsoft.Network/networkInterfaces/nic-vm"
-    error_message = "The association must update the NIC in the VM subscription."
+    condition     = azapi_resource.virtualmachine_network_interfaces["primary"].parent_id == "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-vm"
+    error_message = "The interface must be created in the VM subscription, derived from its subnet."
   }
   assert {
-    condition     = azurerm_network_interface_application_gateway_backend_address_pool_association.this["primary-primary-shared"].backend_address_pool_id == "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/rg-gateway/providers/Microsoft.Network/applicationGateways/agw-shared/backendAddressPools/pool-shared"
-    error_message = "The association must preserve the full backend pool resource ID from the Application Gateway subscription."
+    condition     = one(local.nic_bodies["primary"].properties.ipConfigurations[0].properties.applicationGatewayBackendAddressPools).id == "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/rg-gateway/providers/Microsoft.Network/applicationGateways/agw-shared/backendAddressPools/pool-shared"
+    error_message = "The interface body must preserve the full backend pool resource ID from the Application Gateway subscription."
   }
 }

--- a/tests/unit/interface_diagnostic_settings.tftest.hcl
+++ b/tests/unit/interface_diagnostic_settings.tftest.hcl
@@ -1,4 +1,13 @@
-mock_provider "azapi" {}
+mock_provider "azapi" {
+  # The virtual machine is still an azurerm resource and parses each network_interface_ids entry as
+  # an ARM ID, so the mocked interface must carry a well-formed one rather than the generated
+  # placeholder.
+  mock_resource "azapi_resource" {
+    defaults = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/networkInterfaces/nic-test"
+    }
+  }
+}
 mock_provider "azurerm" {
   # AzAPI validates parent_id at plan time, so every mocked resource that becomes a parent must
   # carry a well-formed ARM ID rather than the generated placeholder.

--- a/tests/unit/interface_locks.tftest.hcl
+++ b/tests/unit/interface_locks.tftest.hcl
@@ -1,4 +1,13 @@
-mock_provider "azapi" {}
+mock_provider "azapi" {
+  # The virtual machine is still an azurerm resource and parses each network_interface_ids entry as
+  # an ARM ID, so the mocked interface must carry a well-formed one rather than the generated
+  # placeholder.
+  mock_resource "azapi_resource" {
+    defaults = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/networkInterfaces/nic-test"
+    }
+  }
+}
 mock_provider "azurerm" {
   # AzAPI validates parent_id at plan time, so every mocked resource that becomes a parent must
   # carry a well-formed ARM ID rather than the generated placeholder.

--- a/tests/unit/interface_role_assignments.tftest.hcl
+++ b/tests/unit/interface_role_assignments.tftest.hcl
@@ -1,4 +1,12 @@
 mock_provider "azapi" {
+  # The virtual machine is still an azurerm resource and parses each network_interface_ids entry as
+  # an ARM ID, so the mocked interface must carry a well-formed one rather than the generated
+  # placeholder.
+  mock_resource "azapi_resource" {
+    defaults = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/networkInterfaces/nic-test"
+    }
+  }
   # The interfaces utility resolves built-in role names to definition IDs through this data source.
   # Without a mock its output is unset and the lookup fails.
   mock_data "azapi_resource_list" {

--- a/tests/unit/network_interface_body.tftest.hcl
+++ b/tests/unit/network_interface_body.tftest.hcl
@@ -1,0 +1,219 @@
+mock_provider "azapi" {
+  # The virtual machine is still an azurerm resource and parses each network_interface_ids entry as
+  # an ARM ID, so the mocked interface must carry a well-formed one rather than the generated
+  # placeholder.
+  mock_resource "azapi_resource" {
+    defaults = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/networkInterfaces/nic-test"
+    }
+  }
+}
+mock_provider "azurerm" {}
+mock_provider "modtm" {}
+mock_provider "random" {}
+mock_provider "tls" {}
+
+variables {
+  location            = "eastus"
+  name                = "vm-nic-body"
+  resource_group_name = "rg-test"
+  zone                = "1"
+  os_type             = "Linux"
+  account_credentials = {
+    admin_credentials = {
+      generate_admin_password_or_ssh_key = false
+      ssh_keys                           = ["ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQChdqi+GemIsVzHEtcwAuBai8F9qfDB0vvCukphTa4WGZFJ4BJCTGhzNU3FZmBlP8/uuF8MVKXwDFsM8dSZnWldbGTBK/US6qBHK4ewu/8Fd4AqT00yPeb4354wcvyluAKqLeXh29/ILTSO/WlW4tGD/Mzx9B/qicYHyEqrYY307yAiTHps3Yi02OzG1BAprhdDz3OCyzvjgHeM8ltKokrv1/+h49oTX96pIsSVNaH6RBIsSiTSD4DAnlpeqrSacwP6az1IDFfkDob6hn2I29lJitQWuIw/Vi2hiUysPqPhs8StpXfasVfjK8NwQA0eu3KBRAGSM6OnXk+NVxeise45rjRVBKtSLd37KRQWZrOcvorlG8nZRn8TDZc8ECQbF/FJQRApT0Vf0Yxf1sdEwpcNO9/o6vnhhEY4KbFbE53xQsx0+QXdQQ+Milg7F8P/lIW9/fFVBSG07kg1qtOpj4LaHxGfwFZwyCWSAvAJ13WIlomCO/HLY3aa07zO3l6jowofJzh3WVHCaGL/Gwg1KuNYS1Hi0Hu0KXwAKeS1YQnkdfaDD7Xvf2TeP3Jzis8iDWyXrZav1XVgtOcDsOkQ3lTkdhunRGyOeqCJrxBvCAiG+N3Lb4h09SJVOIN54lBZAUFRGWjbmawNPfQkTYt8asep/yrLsfokyrBlei6rdacHPQ== avm-unit-test"]
+    }
+  }
+  network_interfaces = {
+    nic1 = {
+      name = "nic-test"
+      ip_configurations = {
+        ipconfig1 = {
+          name                          = "ipconfig1"
+          private_ip_subnet_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-test/subnets/snet-test"
+        }
+      }
+    }
+  }
+  source_image_reference = {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-focal"
+    sku       = "20_04-lts-gen2"
+    version   = "latest"
+  }
+}
+
+run "ip_configuration_defaults_are_mapped_to_arm_names" {
+  command = apply
+
+  assert {
+    condition     = local.nic_bodies["nic1"].properties.ipConfigurations[0].name == "ipconfig1"
+    error_message = "The IP configuration name must be carried into the interface body."
+  }
+  assert {
+    condition     = local.nic_bodies["nic1"].properties.ipConfigurations[0].properties.primary == true
+    error_message = "is_primary_ipconfiguration must map to properties.primary."
+  }
+  assert {
+    condition     = local.nic_bodies["nic1"].properties.ipConfigurations[0].properties.privateIPAllocationMethod == "Dynamic"
+    error_message = "private_ip_address_allocation must map to properties.privateIPAllocationMethod."
+  }
+  assert {
+    condition     = local.nic_bodies["nic1"].properties.ipConfigurations[0].properties.privateIPAddressVersion == "IPv4"
+    error_message = "private_ip_address_version must map to properties.privateIPAddressVersion."
+  }
+  assert {
+    condition     = local.nic_bodies["nic1"].properties.ipConfigurations[0].properties.subnet.id == "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-test/subnets/snet-test"
+    error_message = "private_ip_subnet_resource_id must map to properties.subnet.id."
+  }
+}
+
+run "omitted_optional_properties_are_absent_from_the_body" {
+  command = apply
+
+  assert {
+    condition     = !can(local.nic_bodies["nic1"].properties.ipConfigurations[0].properties.privateIPAddress)
+    error_message = "A null private_ip_address must be omitted rather than sent as null."
+  }
+  assert {
+    condition     = !can(local.nic_bodies["nic1"].properties.dnsSettings)
+    error_message = "dnsSettings must be omitted when neither dns_servers nor internal_dns_name_label is supplied."
+  }
+  assert {
+    condition     = !can(local.nic_bodies["nic1"].properties.networkSecurityGroup)
+    error_message = "networkSecurityGroup must be omitted when no network security group is supplied."
+  }
+  assert {
+    condition     = !can(local.nic_bodies["nic1"].properties.ipConfigurations[0].properties.applicationSecurityGroups)
+    error_message = "applicationSecurityGroups must be omitted when none are supplied."
+  }
+}
+
+run "interface_level_flags_and_dns_are_mapped" {
+  command = apply
+
+  variables {
+    network_interfaces = {
+      nic1 = {
+        name                           = "nic-test"
+        accelerated_networking_enabled = true
+        ip_forwarding_enabled          = true
+        dns_servers                    = ["10.0.0.4", "10.0.0.5"]
+        internal_dns_name_label        = "internal-label"
+        ip_configurations = {
+          ipconfig1 = {
+            name                          = "ipconfig1"
+            private_ip_address            = "10.0.0.10"
+            private_ip_address_allocation = "Static"
+            private_ip_subnet_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-test/subnets/snet-test"
+          }
+        }
+      }
+    }
+  }
+
+  assert {
+    condition     = local.nic_bodies["nic1"].properties.enableAcceleratedNetworking == true
+    error_message = "accelerated_networking_enabled must map to properties.enableAcceleratedNetworking."
+  }
+  assert {
+    condition     = local.nic_bodies["nic1"].properties.enableIPForwarding == true
+    error_message = "ip_forwarding_enabled must map to properties.enableIPForwarding."
+  }
+  assert {
+    condition     = local.nic_bodies["nic1"].properties.dnsSettings.dnsServers == tolist(["10.0.0.4", "10.0.0.5"])
+    error_message = "dns_servers must map to properties.dnsSettings.dnsServers."
+  }
+  assert {
+    condition     = local.nic_bodies["nic1"].properties.dnsSettings.internalDnsNameLabel == "internal-label"
+    error_message = "internal_dns_name_label must map to properties.dnsSettings.internalDnsNameLabel."
+  }
+  assert {
+    condition     = local.nic_bodies["nic1"].properties.ipConfigurations[0].properties.privateIPAddress == "10.0.0.10"
+    error_message = "A supplied private_ip_address must appear in the body."
+  }
+}
+
+run "associations_are_folded_into_the_interface_body" {
+  command = apply
+
+  variables {
+    network_interfaces = {
+      nic1 = {
+        name = "nic-test"
+        network_security_groups = {
+          nsg1 = {
+            network_security_group_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/networkSecurityGroups/nsg-test"
+          }
+        }
+        application_security_groups = {
+          asg1 = {
+            application_security_group_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/applicationSecurityGroups/asg-test"
+          }
+        }
+        ip_configurations = {
+          ipconfig1 = {
+            name                          = "ipconfig1"
+            private_ip_subnet_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-test/subnets/snet-test"
+            load_balancer_backend_pools = {
+              lb1 = {
+                load_balancer_backend_pool_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/loadBalancers/lb-test/backendAddressPools/pool-test"
+              }
+            }
+            load_balancer_nat_rules = {
+              nat1 = {
+                load_balancer_nat_rule_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/loadBalancers/lb-test/inboundNatRules/nat-test"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  assert {
+    condition     = local.nic_bodies["nic1"].properties.networkSecurityGroup.id == "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/networkSecurityGroups/nsg-test"
+    error_message = "The network security group association must become properties.networkSecurityGroup on the interface."
+  }
+  assert {
+    condition     = one(local.nic_bodies["nic1"].properties.ipConfigurations[0].properties.applicationSecurityGroups).id == "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/applicationSecurityGroups/asg-test"
+    error_message = "The interface-level application security group must be replicated onto each IP configuration."
+  }
+  assert {
+    condition     = one(local.nic_bodies["nic1"].properties.ipConfigurations[0].properties.loadBalancerBackendAddressPools).id == "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/loadBalancers/lb-test/backendAddressPools/pool-test"
+    error_message = "The load balancer backend pool association must become a property of the IP configuration."
+  }
+  assert {
+    condition     = one(local.nic_bodies["nic1"].properties.ipConfigurations[0].properties.loadBalancerInboundNatRules).id == "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/loadBalancers/lb-test/inboundNatRules/nat-test"
+    error_message = "The load balancer NAT rule association must become a property of the IP configuration."
+  }
+}
+
+run "more_than_one_network_security_group_is_rejected" {
+  command = plan
+
+  variables {
+    network_interfaces = {
+      nic1 = {
+        name = "nic-test"
+        network_security_groups = {
+          nsg1 = {
+            network_security_group_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/networkSecurityGroups/nsg-one"
+          }
+          nsg2 = {
+            network_security_group_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/networkSecurityGroups/nsg-two"
+          }
+        }
+        ip_configurations = {
+          ipconfig1 = {
+            name                          = "ipconfig1"
+            private_ip_subnet_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-test/subnets/snet-test"
+          }
+        }
+      }
+    }
+  }
+
+  expect_failures = [azapi_resource.virtualmachine_network_interfaces]
+}

--- a/tests/unit/network_parent_id.tftest.hcl
+++ b/tests/unit/network_parent_id.tftest.hcl
@@ -1,0 +1,125 @@
+mock_provider "azapi" {
+  # The virtual machine is still an azurerm resource and parses each network_interface_ids entry as
+  # an ARM ID, so the mocked interface must carry a well-formed one rather than the generated
+  # placeholder.
+  mock_resource "azapi_resource" {
+    defaults = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/networkInterfaces/nic-test"
+    }
+  }
+}
+mock_provider "azurerm" {}
+mock_provider "modtm" {}
+mock_provider "random" {}
+mock_provider "tls" {}
+
+variables {
+  location            = "eastus"
+  name                = "vm-parent-id"
+  resource_group_name = "rg-test"
+  zone                = "1"
+  os_type             = "Linux"
+  account_credentials = {
+    admin_credentials = {
+      generate_admin_password_or_ssh_key = false
+      ssh_keys                           = ["ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQChdqi+GemIsVzHEtcwAuBai8F9qfDB0vvCukphTa4WGZFJ4BJCTGhzNU3FZmBlP8/uuF8MVKXwDFsM8dSZnWldbGTBK/US6qBHK4ewu/8Fd4AqT00yPeb4354wcvyluAKqLeXh29/ILTSO/WlW4tGD/Mzx9B/qicYHyEqrYY307yAiTHps3Yi02OzG1BAprhdDz3OCyzvjgHeM8ltKokrv1/+h49oTX96pIsSVNaH6RBIsSiTSD4DAnlpeqrSacwP6az1IDFfkDob6hn2I29lJitQWuIw/Vi2hiUysPqPhs8StpXfasVfjK8NwQA0eu3KBRAGSM6OnXk+NVxeise45rjRVBKtSLd37KRQWZrOcvorlG8nZRn8TDZc8ECQbF/FJQRApT0Vf0Yxf1sdEwpcNO9/o6vnhhEY4KbFbE53xQsx0+QXdQQ+Milg7F8P/lIW9/fFVBSG07kg1qtOpj4LaHxGfwFZwyCWSAvAJ13WIlomCO/HLY3aa07zO3l6jowofJzh3WVHCaGL/Gwg1KuNYS1Hi0Hu0KXwAKeS1YQnkdfaDD7Xvf2TeP3Jzis8iDWyXrZav1XVgtOcDsOkQ3lTkdhunRGyOeqCJrxBvCAiG+N3Lb4h09SJVOIN54lBZAUFRGWjbmawNPfQkTYt8asep/yrLsfokyrBlei6rdacHPQ== avm-unit-test"]
+    }
+  }
+  network_interfaces = {
+    nic1 = {
+      name = "nic-test"
+      ip_configurations = {
+        ipconfig1 = {
+          name                          = "ipconfig1"
+          private_ip_subnet_resource_id = "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/rg-network/providers/Microsoft.Network/virtualNetworks/vnet-test/subnets/snet-test"
+        }
+      }
+    }
+  }
+  source_image_reference = {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-focal"
+    sku       = "20_04-lts-gen2"
+    version   = "latest"
+  }
+}
+
+run "subscription_is_derived_from_the_subnet_when_parent_id_is_omitted" {
+  command = apply
+
+  assert {
+    condition     = local.subscription_id == "11111111-1111-1111-1111-111111111111"
+    error_message = "The subscription must be taken from the subnet resource ID, which Azure guarantees shares the interface's subscription."
+  }
+  assert {
+    condition     = azapi_resource.virtualmachine_network_interfaces["nic1"].parent_id == "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/rg-test"
+    error_message = "The interface parent must combine the derived subscription with resource_group_name."
+  }
+}
+
+run "explicit_parent_id_wins_over_the_derived_value" {
+  command = apply
+
+  variables {
+    parent_id = "/subscriptions/22222222-2222-2222-2222-222222222222/resourceGroups/rg-explicit"
+  }
+
+  assert {
+    condition     = azapi_resource.virtualmachine_network_interfaces["nic1"].parent_id == "/subscriptions/22222222-2222-2222-2222-222222222222/resourceGroups/rg-explicit"
+    error_message = "A supplied parent_id must be used verbatim."
+  }
+}
+
+run "per_interface_resource_group_overrides_the_parent" {
+  command = apply
+
+  variables {
+    parent_id = "/subscriptions/22222222-2222-2222-2222-222222222222/resourceGroups/rg-explicit"
+    network_interfaces = {
+      nic1 = {
+        name                = "nic-test"
+        resource_group_name = "rg-interface"
+        ip_configurations = {
+          ipconfig1 = {
+            name                          = "ipconfig1"
+            private_ip_subnet_resource_id = "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/rg-network/providers/Microsoft.Network/virtualNetworks/vnet-test/subnets/snet-test"
+          }
+        }
+      }
+    }
+  }
+
+  assert {
+    condition     = azapi_resource.virtualmachine_network_interfaces["nic1"].parent_id == "/subscriptions/22222222-2222-2222-2222-222222222222/resourceGroups/rg-interface"
+    error_message = "A per-interface resource_group_name must replace the resource group while keeping the parent_id subscription."
+  }
+}
+
+run "a_malformed_parent_id_is_rejected" {
+  command = plan
+
+  variables {
+    parent_id = "/subscriptions/22222222-2222-2222-2222-222222222222"
+  }
+
+  expect_failures = [var.parent_id]
+}
+
+run "an_interface_without_a_subnet_or_parent_id_is_rejected" {
+  command = plan
+
+  variables {
+    network_interfaces = {
+      nic1 = {
+        name = "nic-test"
+        ip_configurations = {
+          ipconfig1 = {
+            name = "ipconfig1"
+          }
+        }
+      }
+    }
+  }
+
+  expect_failures = [azapi_resource.virtualmachine_network_interfaces]
+}

--- a/tests/unit/os_disk_attach_mode.tftest.hcl
+++ b/tests/unit/os_disk_attach_mode.tftest.hcl
@@ -4,7 +4,16 @@
 # the module leaves them null. The defaults are therefore deliberately the opposite of the values
 # fed in through `variables`, so a value that leaks through the guard is distinguishable from a
 # value that was correctly nulled out.
-mock_provider "azapi" {}
+mock_provider "azapi" {
+  # The virtual machine is still an azurerm resource and parses each network_interface_ids entry as
+  # an ARM ID, so the mocked interface must carry a well-formed one rather than the generated
+  # placeholder.
+  mock_resource "azapi_resource" {
+    defaults = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/networkInterfaces/nic-test"
+    }
+  }
+}
 mock_provider "azurerm" {
   mock_resource "azurerm_network_interface" {
     defaults = {

--- a/tests/unit/os_disk_lock.tftest.hcl
+++ b/tests/unit/os_disk_lock.tftest.hcl
@@ -1,4 +1,13 @@
-mock_provider "azapi" {}
+mock_provider "azapi" {
+  # The virtual machine is still an azurerm resource and parses each network_interface_ids entry as
+  # an ARM ID, so the mocked interface must carry a well-formed one rather than the generated
+  # placeholder.
+  mock_resource "azapi_resource" {
+    defaults = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/networkInterfaces/nic-test"
+    }
+  }
+}
 mock_provider "azurerm" {
   mock_resource "azurerm_network_interface" {
     defaults = {

--- a/tests/unit/os_disk_network_access.tftest.hcl
+++ b/tests/unit/os_disk_network_access.tftest.hcl
@@ -1,4 +1,13 @@
-mock_provider "azapi" {}
+mock_provider "azapi" {
+  # The virtual machine is still an azurerm resource and parses each network_interface_ids entry as
+  # an ARM ID, so the mocked interface must carry a well-formed one rather than the generated
+  # placeholder.
+  mock_resource "azapi_resource" {
+    defaults = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/networkInterfaces/nic-test"
+    }
+  }
+}
 mock_provider "azurerm" {
   mock_resource "azurerm_network_interface" {
     defaults = {

--- a/tests/unit/public_ip_body.tftest.hcl
+++ b/tests/unit/public_ip_body.tftest.hcl
@@ -1,0 +1,137 @@
+mock_provider "azapi" {
+  # The virtual machine is still an azurerm resource and parses each network_interface_ids entry as
+  # an ARM ID, so the mocked interface must carry a well-formed one rather than the generated
+  # placeholder.
+  mock_resource "azapi_resource" {
+    defaults = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/networkInterfaces/nic-test"
+    }
+  }
+}
+mock_provider "azurerm" {}
+mock_provider "modtm" {}
+mock_provider "random" {}
+mock_provider "tls" {}
+
+variables {
+  location            = "eastus"
+  name                = "vm-public-ip"
+  resource_group_name = "rg-test"
+  zone                = "1"
+  os_type             = "Linux"
+  account_credentials = {
+    admin_credentials = {
+      generate_admin_password_or_ssh_key = false
+      ssh_keys                           = ["ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQChdqi+GemIsVzHEtcwAuBai8F9qfDB0vvCukphTa4WGZFJ4BJCTGhzNU3FZmBlP8/uuF8MVKXwDFsM8dSZnWldbGTBK/US6qBHK4ewu/8Fd4AqT00yPeb4354wcvyluAKqLeXh29/ILTSO/WlW4tGD/Mzx9B/qicYHyEqrYY307yAiTHps3Yi02OzG1BAprhdDz3OCyzvjgHeM8ltKokrv1/+h49oTX96pIsSVNaH6RBIsSiTSD4DAnlpeqrSacwP6az1IDFfkDob6hn2I29lJitQWuIw/Vi2hiUysPqPhs8StpXfasVfjK8NwQA0eu3KBRAGSM6OnXk+NVxeise45rjRVBKtSLd37KRQWZrOcvorlG8nZRn8TDZc8ECQbF/FJQRApT0Vf0Yxf1sdEwpcNO9/o6vnhhEY4KbFbE53xQsx0+QXdQQ+Milg7F8P/lIW9/fFVBSG07kg1qtOpj4LaHxGfwFZwyCWSAvAJ13WIlomCO/HLY3aa07zO3l6jowofJzh3WVHCaGL/Gwg1KuNYS1Hi0Hu0KXwAKeS1YQnkdfaDD7Xvf2TeP3Jzis8iDWyXrZav1XVgtOcDsOkQ3lTkdhunRGyOeqCJrxBvCAiG+N3Lb4h09SJVOIN54lBZAUFRGWjbmawNPfQkTYt8asep/yrLsfokyrBlei6rdacHPQ== avm-unit-test"]
+    }
+  }
+  network_interfaces = {
+    nic1 = {
+      name = "nic-test"
+      ip_configurations = {
+        ipconfig1 = {
+          name                          = "ipconfig1"
+          private_ip_subnet_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-test/subnets/snet-test"
+          create_public_ip_address      = true
+          public_ip_address_name        = "pip-test"
+        }
+      }
+    }
+  }
+  source_image_reference = {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-focal"
+    sku       = "20_04-lts-gen2"
+    version   = "latest"
+  }
+}
+
+run "public_ip_defaults_are_mapped_to_arm_names" {
+  command = apply
+
+  assert {
+    condition     = local.public_ip_body.properties.publicIPAllocationMethod == "Static"
+    error_message = "allocation_method must map to properties.publicIPAllocationMethod."
+  }
+  assert {
+    condition     = local.public_ip_body.properties.publicIPAddressVersion == "IPv4"
+    error_message = "ip_version must map to properties.publicIPAddressVersion."
+  }
+  assert {
+    condition     = local.public_ip_body.properties.idleTimeoutInMinutes == 30
+    error_message = "idle_timeout_in_minutes must map to properties.idleTimeoutInMinutes."
+  }
+  assert {
+    condition     = local.public_ip_body.sku.name == "Standard" && local.public_ip_body.sku.tier == "Regional"
+    error_message = "sku and sku_tier must map to the ARM sku object."
+  }
+  assert {
+    condition     = local.public_ip_body.zones == tolist(["1", "2", "3"])
+    error_message = "zones must be carried into the body as a sorted list."
+  }
+  assert {
+    condition     = local.public_ip_body.properties.ddosSettings.protectionMode == "VirtualNetworkInherited"
+    error_message = "ddos_protection_mode must map to properties.ddosSettings.protectionMode."
+  }
+  assert {
+    condition     = !can(local.public_ip_body.properties.dnsSettings)
+    error_message = "dnsSettings must be omitted when no domain_name_label is supplied."
+  }
+}
+
+run "public_ip_is_created_in_the_derived_resource_group" {
+  command = apply
+
+  assert {
+    condition     = azapi_resource.virtualmachine_public_ips["nic1-ipconfig1"].parent_id == "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test"
+    error_message = "The public IP must be created in resource_group_name using the derived subscription."
+  }
+  assert {
+    condition     = azapi_resource.virtualmachine_public_ips["nic1-ipconfig1"].name == "pip-test"
+    error_message = "The public IP must use the configured public_ip_address_name."
+  }
+}
+
+run "public_ip_is_attached_to_the_ip_configuration" {
+  command = apply
+
+  assert {
+    condition     = local.nic_bodies["nic1"].properties.ipConfigurations[0].properties.publicIPAddress.id == azapi_resource.virtualmachine_public_ips["nic1-ipconfig1"].id
+    error_message = "A created public IP must be referenced from the interface's IP configuration."
+  }
+}
+
+run "optional_public_ip_settings_are_mapped" {
+  command = apply
+
+  variables {
+    public_ip_configuration_details = {
+      allocation_method       = "Static"
+      domain_name_label       = "vm-public-ip-label"
+      ddos_protection_mode    = "Enabled"
+      ddos_protection_plan_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/ddosProtectionPlans/ddos-test"
+      idle_timeout_in_minutes = 15
+      ip_version              = "IPv4"
+      sku                     = "Standard"
+      sku_tier                = "Regional"
+      zones                   = ["1"]
+    }
+  }
+
+  assert {
+    condition     = local.public_ip_body.properties.dnsSettings.domainNameLabel == "vm-public-ip-label"
+    error_message = "domain_name_label must map to properties.dnsSettings.domainNameLabel."
+  }
+  assert {
+    condition     = local.public_ip_body.properties.ddosSettings.ddosProtectionPlan.id == "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/ddosProtectionPlans/ddos-test"
+    error_message = "ddos_protection_plan_id must map to properties.ddosSettings.ddosProtectionPlan.id."
+  }
+  assert {
+    condition     = local.public_ip_body.properties.idleTimeoutInMinutes == 15
+    error_message = "A supplied idle_timeout_in_minutes must be carried into the body."
+  }
+  assert {
+    condition     = local.public_ip_body.zones == tolist(["1"])
+    error_message = "A supplied zone set must be carried into the body."
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -729,6 +729,8 @@ variable "ignore_body_changes" {
     authorization_locks                   = optional(list(string), [])
     authorization_role_assignments        = optional(list(string), [])
     insights_diagnostic_settings          = optional(list(string), [])
+    network_network_interfaces            = optional(list(string), [])
+    network_public_ip_addresses           = optional(list(string), [])
 
     recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems = optional(object({
       recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems = optional(list(string), [])
@@ -748,6 +750,8 @@ apply.
 - `authorization_locks` - Ignored body paths for the management locks.
 - `authorization_role_assignments` - Ignored body paths for the role assignments.
 - `insights_diagnostic_settings` - Ignored body paths for the diagnostic settings.
+- `network_network_interfaces` - Ignored body paths for the network interfaces.
+- `network_public_ip_addresses` - Ignored body paths for the public IP addresses.
 - `recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems` - Paths passed to the backup submodule.
 - `recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems.recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems` - Ignored body paths for the backup protected item.
 DESCRIPTION
@@ -989,7 +993,7 @@ A map of objects representing each network virtual machine network interface
       - `principal_type`                             = (Optional) - The type of the `principal_id`. Possible values are `User`, `Group` and `ServicePrincipal`. It is necessary to explicitly set this attribute when creating role assignments if the principal creating the assignment is constrained by ABAC rules that filters on the PrincipalType attribute.
   - `tags`                           = (Optional) - A mapping of tags to assign to the resource.
 
-> Note: There is no per network interface `delete_option` input because the `azurerm` provider does not expose `networkProfile.networkInterfaces[].deleteOption`; `network_interface_ids` on the virtual machine resource is a plain list of IDs. This module creates each network interface as its own `azurerm_network_interface` resource, so `terraform destroy` deletes them along with the virtual machine and they are not orphaned. That setting only affects deletions performed outside Terraform.
+> Note: There is no per network interface `delete_option` input because the `azurerm` provider does not expose `networkProfile.networkInterfaces[].deleteOption`; `network_interface_ids` on the virtual machine resource is a plain list of IDs. This module creates each network interface as its own `azapi_resource` resource, so `terraform destroy` deletes them along with the virtual machine and they are not orphaned. That setting only affects deletions performed outside Terraform.
 
 Example Inputs:
 
@@ -1211,6 +1215,34 @@ variable "os_type" {
   }
 }
 
+variable "parent_id" {
+  type        = string
+  default     = null
+  description = <<DESCRIPTION
+The fully-qualified ARM resource ID of the resource group the network interfaces and public IP
+addresses are deployed into, for example
+`/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}`.
+
+When omitted, the subscription is derived from the first `private_ip_subnet_resource_id` supplied
+on any IP configuration. Azure requires a network interface and its subnet to share a subscription,
+so the derived value is correct wherever a subnet is supplied. The resource group name continues to
+come from `resource_group_name`, or from a network interface's own `resource_group_name`.
+
+This value **must be known at plan time**. An unknown value causes AzAPI to replace the resource
+rather than update it in place, which for an existing network interface means a destroy and
+recreate. Deriving from the subnet is only unknown while that subnet is itself being created or
+replaced. Set this input explicitly if you ever replace the subnet underneath an existing virtual
+machine, so the interface is not dragged into the replacement.
+
+At least one of `parent_id` or a `private_ip_subnet_resource_id` must be supplied.
+DESCRIPTION
+
+  validation {
+    condition     = var.parent_id == null || can(regex("^/subscriptions/[^/]+/resourceGroups/[^/]+$", var.parent_id))
+    error_message = "The parent_id must be a resource group resource ID (e.g. /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName})."
+  }
+}
+
 variable "patch_assessment_mode" {
   type        = string
   default     = "ImageDefault"
@@ -1344,6 +1376,8 @@ variable "resource_types" {
     authorization_locks                   = optional(string, "Microsoft.Authorization/locks@2020-05-01")
     authorization_role_assignments        = optional(string, "Microsoft.Authorization/roleAssignments@2022-04-01")
     insights_diagnostic_settings          = optional(string, "Microsoft.Insights/diagnosticSettings@2021-05-01-preview")
+    network_network_interfaces            = optional(string, "Microsoft.Network/networkInterfaces@2024-10-01")
+    network_public_ip_addresses           = optional(string, "Microsoft.Network/publicIPAddresses@2024-10-01")
 
     recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems = optional(object({
       recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems = optional(string)
@@ -1360,6 +1394,8 @@ sovereign cloud with older API versions, or when opting into a newer preview API
 - `authorization_locks` - Management locks applied to the virtual machine and its child resources.
 - `authorization_role_assignments` - Role assignments applied to the virtual machine and its child resources.
 - `insights_diagnostic_settings` - Diagnostic settings applied to the virtual machine and its OS disk.
+- `network_network_interfaces` - The network interfaces created for the virtual machine.
+- `network_public_ip_addresses` - The public IP addresses created for the virtual machine's IP configurations.
 - `recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems` - Resource-type overrides passed to the backup submodule.
 - `recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems.recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems` - The backup protected item.
 DESCRIPTION


### PR DESCRIPTION
## Description

Step 2 of the AzureRM to AzAPI migration, following #387. Converts the **network interface** and the **public IP address**, and folds the five association resources into the interface body — ARM has always modelled those as properties of the interface, never as separate resources.

| Converted | Notes |
|---|---|
| `azurerm_network_interface` | → `azapi_resource`, `moved` |
| `azurerm_public_ip` | → `azapi_resource`, `moved` |
| 5 × `azurerm_network_interface_*_association` | Folded into the interface body, `removed` with `destroy = false` |

The associations are NSG, ASG, load balancer backend pool, Application Gateway backend pool, and NAT rule.

## Trade-offs

**1. `parent_id` is optional and never derived from a data source.**

This is the first step where resources are parented to a *resource group*, so it introduces `var.parent_id`. It stays optional — making it required would break every consumer and all 21 examples.

When omitted, the subscription is derived from a `private_ip_subnet_resource_id` already supplied on an IP configuration. Azure requires a network interface and its subnet to share a subscription, so that value is correct by construction rather than by assumption.

A data source fallback was deliberately **rejected**. The earlier spike proved that a deferred data source makes `parent_id` unknown at plan time, which forces AzAPI to *replace* the interface rather than update it — a destroy/recreate of a NIC attached to a live VM. Deriving from the subnet is only unknown while that subnet is itself being created or replaced, which already implies churn. A precondition reports the case where neither a `parent_id` nor a subnet is available, and the variable documentation tells consumers to set it explicitly if they ever replace a subnet underneath an existing VM.

**2. Outputs keep the `azurerm` shape.**

`network_interfaces` and `public_ips` would otherwise change shape to the raw ARM schema, breaking every consumer expression. Both keep their previous attribute names through a compatibility layer, and the unshaped objects are available as `network_interfaces_azapi` / `public_ips_azapi`.

The cost is a hand-maintained mapping, and an `azurerm`-shaped surface that outlives the provider. The benefit is that this PR is non-breaking for output consumers. There is also an unexpected gain: `mac_address` was `""` under `azurerm` and now resolves correctly, because the shim reads it from the ARM response.

**3. More than one network security group is now an error.**

ARM attaches at most one NSG to an interface, but the input is a `map`. The previous implementation created one association resource per map entry, all targeting the same interface, so entries raced and the last applied won. A precondition now rejects more than one rather than silently discarding the rest. Collapsing the input to a single object is tracked in #391 for the next breaking release.

## Test results

| Check | Result |
|---|---|
| `avm lint` | **pass** |
| `avm pre-commit` | **pass** |
| `avm test unit` | **60 runs, 60 passed, 0 failed** (was 46) |

14 new unit tests cover the interface body mapping, association folding, `parent_id` resolution, the public IP body, and both preconditions.

### Migration verified against real Azure

Unit tests plan against mocks and e2e only creates on empty ground, so neither can prove a `moved`/`removed` state migration. This was verified manually against a real deployment, with the interface **attached to a running VM**:

| Check | Result |
|---|---|
| Migration plan | `0 to add, 4 to change, 0 to destroy` — zero replacements |
| Interface | Appeared at the new `azapi_resource` address as "updated in-place" |
| Apply | `0 added, 4 changed, 0 destroyed` |
| NIC resource ID and private IP | Byte-identical before and after |
| NSG / ASG in Azure | Both still attached after Terraform forgot the association resources |
| VM binding | `virtualMachine.id` unchanged, `provisioningState: Succeeded` |
| Second plan | No interface change — it appears only in the refresh line |

### Known gap

The **public IP has no real-Azure migration coverage**. The test subscription enforces a policy requiring an `ipTag` of `FirstPartyUsage` on every public IP, and the module exposes no `ip_tags` input under either provider, so no module-created public IP is deployable there. That is a pre-existing module gap rather than something this PR introduces, and it is worth a follow-up. The public IP is covered by unit tests and by the e2e examples, which run in a subscription without that policy.

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks
