### PR TITLE
ci: pin Avm.Authoring to 0.9.5 for the azapi migration

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -27,3 +27,10 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    with:
+      # Pinned for the duration of the azurerm -> azapi migration. The reusable workflow installs
+      # the latest Avm.Authoring when this is unset, and 0.10.1 introduced rules that the module
+      # cannot satisfy until the migration completes - most notably provider_azurerm_disallowed,
+      # which fires on every resource the migration has not reached yet. Remove this pin once the
+      # migration removes the azurerm provider.
+      avm-authoring-version: '0.9.5'


### PR DESCRIPTION
## Description

The managed workflow installs the latest `Avm.Authoring` from the PowerShell Gallery when `avm-authoring-version` is left unset. That makes the lint ruleset float, and it has now drifted twice in the middle of the azurerm → azapi migration.

`0.9.5` is the version that was in use when #392 last went green (2026-08-20 20:34 UTC). `0.10.1` was published at 23:34 UTC the same day and enables five rules the module cannot satisfy mid-migration:

| Rule | Hits | Why it cannot be fixed now |
|---|---|---|
| `provider_azurerm_disallowed` | **136** | Fires on every `azurerm` resource the migration has not reached yet — the virtual machines, key vault secrets, shutdown schedule, disk attachments — plus all 21 examples. Only completing the migration satisfies it. |
| `azapi_replace_triggers_refs` | 11 | Rejects `replace_triggers_refs = []`, which the already-merged migration steps use throughout. |
| `azapi_resource_tag` | 3 | Requires exactly `tags = var.tags`, conflicting with the per-resource tag overrides the module exposes today. Changing it is a behaviour change, not a lint fix. |
| `no_entire_resource_output_tffr2` | 3 | Flags the raw `*_azapi` outputs that exist deliberately as escape hatches. |
| `azapi_response_export_values` | 1 | Needs a value on a resource unrelated to any step in flight. |

The first of these is circular: the rule that enforces the azurerm → azapi migration blocks the pull requests performing it. With the toolchain unpinned, **every pull request in this repository currently fails lint**, regardless of its content.

## Trade-offs

**This defers compliance rather than achieving it.** All five rules still have to be addressed. Pinning concentrates that into one deliberate change at the end of the migration instead of scattering unrelated lint churn across migration PRs, where it obscures the actual diff and makes review harder.

**The pin is temporary and self-documenting.** The comment in the workflow states the condition for removal: once the migration removes the `azurerm` provider, drop the pin and address the five rules together. Three of them (`azapi_replace_triggers_refs`, `azapi_response_export_values`, `no_entire_resource_output_tffr2`) are mechanical at that point; `azapi_resource_tag` needs a decision about per-resource tag overrides.

**The alternative considered** was suppressing the rules in `avm.tflint.override.hcl`. That was rejected because `provider_azurerm_disallowed` is a Severity-MUST rule, and silently disabling it repo-wide is a stronger statement than pinning a tool version — it would also stay disabled after the migration unless someone remembered to remove it.

## Test results

| Check | Result |
|---|---|
| Change scope | One `with:` block on the reusable workflow call, no module code touched |
| Verified locally | `avm lint` passes on `0.9.5` and fails on `0.10.1` for the same commit, which is what identified the drift |

This PR's own CI run exercises the pin directly: it is the first run to use the pinned version.

## Type of Change

- [x] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

> [!NOTE]
> #392 is open and was green before this drift. It will need a rerun once this merges.
