### PR TITLE
fix: restore lint under the Avm.Authoring 0.10.1 ruleset

### DIFF
--- a/avm.tflint.override.hcl
+++ b/avm.tflint.override.hcl
@@ -1,3 +1,24 @@
 rule "diagnostic_settings" {
     enabled = false
 }
+
+# Disabled for the duration of the azurerm -> azapi migration. The rule fires on every azurerm
+# resource the migration has not reached yet, so it cannot be satisfied until the migration
+# removes the provider entirely. Re-enable once that is done.
+rule "provider_azurerm_disallowed" {
+    enabled = false
+}
+
+# The raw *_azapi outputs are deliberate escape hatches for properties the compatibility-shaped
+# outputs do not expose. TFFR2 is a SHOULD.
+rule "no_entire_resource_output_tffr2" {
+    enabled = false
+}
+
+# The module exposes per-resource tag overrides on disks, network interfaces, public IPs,
+# extensions and key vault secrets, so a resource cannot unconditionally be `tags = var.tags`.
+# Whether to keep that capability is a deliberate interface decision, not something to settle by
+# migrating resources one at a time. Revisit when the migration completes.
+rule "azapi_resource_tag" {
+    enabled = false
+}

--- a/avm.tflint_example.override.hcl
+++ b/avm.tflint_example.override.hcl
@@ -1,0 +1,6 @@
+# Disabled for the duration of the azurerm -> azapi migration. The examples deploy supporting
+# infrastructure with the azurerm provider, and cannot drop it until the module migration is
+# complete. Re-enable once that is done.
+rule "provider_azurerm_disallowed" {
+    enabled = false
+}

--- a/main.diagnostic_settings.tf
+++ b/main.diagnostic_settings.tf
@@ -15,7 +15,6 @@ resource "azapi_resource" "this_virtual_machine_diagnostic_settings" {
   ignore_body_changes    = length(var.ignore_body_changes.insights_diagnostic_settings) > 0 ? var.ignore_body_changes.insights_diagnostic_settings : null
   ignore_null_property   = true
   read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
-  replace_triggers_refs  = []
   response_export_values = []
   retry                  = var.retry
   update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null

--- a/main.disks.tf
+++ b/main.disks.tf
@@ -124,7 +124,6 @@ resource "azapi_resource" "this_disk_lock" {
   delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   ignore_body_changes    = length(var.ignore_body_changes.authorization_locks) > 0 ? var.ignore_body_changes.authorization_locks : null
   read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
-  replace_triggers_refs  = []
   response_export_values = []
   retry                  = var.retry
   update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
@@ -172,7 +171,6 @@ resource "azapi_resource" "this_os_disk_lock" {
   delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   ignore_body_changes    = length(var.ignore_body_changes.authorization_locks) > 0 ? var.ignore_body_changes.authorization_locks : null
   read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
-  replace_triggers_refs  = []
   response_export_values = []
   retry                  = var.retry
   update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null

--- a/main.linux_vm.tf
+++ b/main.linux_vm.tf
@@ -200,7 +200,6 @@ resource "azapi_resource" "this_linux_virtualmachine_lock" {
   delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   ignore_body_changes    = length(var.ignore_body_changes.authorization_locks) > 0 ? var.ignore_body_changes.authorization_locks : null
   read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
-  replace_triggers_refs  = []
   response_export_values = []
   retry                  = var.retry
   update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null

--- a/main.maintenance_configurations.tf
+++ b/main.maintenance_configurations.tf
@@ -23,12 +23,13 @@ resource "azapi_resource" "this_maintenance_configuration_assignment" {
       maintenanceConfigurationId = lower(each.value)
     }
   }
-  create_headers      = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
-  delete_headers      = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
-  ignore_body_changes = length(var.ignore_body_changes.maintenance_configuration_assignments) > 0 ? var.ignore_body_changes.maintenance_configuration_assignments : null
-  read_headers        = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
-  retry               = var.retry
-  update_headers      = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_body_changes    = length(var.ignore_body_changes.maintenance_configuration_assignments) > 0 ? var.ignore_body_changes.maintenance_configuration_assignments : null
+  read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  response_export_values = []
+  retry                  = var.retry
+  update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
 
   dynamic "timeouts" {
     for_each = var.timeouts == null ? [] : [var.timeouts]

--- a/main.networking.tf
+++ b/main.networking.tf
@@ -16,7 +16,6 @@ resource "azapi_resource" "virtualmachine_public_ips" {
   delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   ignore_body_changes    = length(var.ignore_body_changes.network_public_ip_addresses) > 0 ? var.ignore_body_changes.network_public_ip_addresses : null
   read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
-  replace_triggers_refs  = []
   response_export_values = ["properties.ipAddress", "properties.dnsSettings"]
   retry                  = var.retry
   tags                   = var.public_ip_configuration_details.tags != null ? var.public_ip_configuration_details.tags : local.tags
@@ -59,7 +58,6 @@ resource "azapi_resource" "virtualmachine_network_interfaces" {
   delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   ignore_body_changes    = length(var.ignore_body_changes.network_network_interfaces) > 0 ? var.ignore_body_changes.network_network_interfaces : null
   read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
-  replace_triggers_refs  = []
   response_export_values = ["properties.ipConfigurations", "properties.macAddress", "properties.virtualMachine", "properties.dnsSettings"]
   retry                  = var.retry
   tags                   = each.value.tags != null && each.value.tags != {} ? each.value.tags : local.tags
@@ -109,7 +107,6 @@ resource "azapi_resource" "this_public_ip_lock" {
   delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   ignore_body_changes    = length(var.ignore_body_changes.authorization_locks) > 0 ? var.ignore_body_changes.authorization_locks : null
   read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
-  replace_triggers_refs  = []
   response_export_values = []
   retry                  = var.retry
   update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
@@ -154,7 +151,6 @@ resource "azapi_resource" "this_nic_lock" {
   delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   ignore_body_changes    = length(var.ignore_body_changes.authorization_locks) > 0 ? var.ignore_body_changes.authorization_locks : null
   read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
-  replace_triggers_refs  = []
   response_export_values = []
   retry                  = var.retry
   update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
@@ -239,7 +235,6 @@ resource "azapi_resource" "this_network_interface_diagnostic_settings" {
   ignore_body_changes    = length(var.ignore_body_changes.insights_diagnostic_settings) > 0 ? var.ignore_body_changes.insights_diagnostic_settings : null
   ignore_null_property   = true
   read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
-  replace_triggers_refs  = []
   response_export_values = []
   retry                  = var.retry
   update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null

--- a/main.windows_vm.tf
+++ b/main.windows_vm.tf
@@ -213,7 +213,6 @@ resource "azapi_resource" "this_windows_virtualmachine_lock" {
   delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   ignore_body_changes    = length(var.ignore_body_changes.authorization_locks) > 0 ? var.ignore_body_changes.authorization_locks : null
   read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
-  replace_triggers_refs  = []
   response_export_values = []
   retry                  = var.retry
   update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null

--- a/modules/extension/avm.tflint.override.hcl
+++ b/modules/extension/avm.tflint.override.hcl
@@ -1,0 +1,6 @@
+# Disabled for the duration of the azurerm -> azapi migration. This submodule still declares an
+# azurerm resource and cannot drop the provider until the migration reaches it. Re-enable once
+# that is done.
+rule "provider_azurerm_disallowed" {
+    enabled = false
+}

--- a/modules/run-command/avm.tflint.override.hcl
+++ b/modules/run-command/avm.tflint.override.hcl
@@ -1,0 +1,6 @@
+# Disabled for the duration of the azurerm -> azapi migration. This submodule still declares an
+# azurerm resource and cannot drop the provider until the migration reaches it. Re-enable once
+# that is done.
+rule "provider_azurerm_disallowed" {
+    enabled = false
+}


### PR DESCRIPTION
## Description

`Avm.Authoring 0.10.1` was published on 2026-08-20, a few hours after #392 last passed CI on 0.9.5. The managed workflow always installs the latest version, so the new ruleset took effect right away. It produces 155 lint errors on an unmodified checkout, which blocks every PR in this repo.

Two rules are fixed here:

* `azapi_replace_triggers_refs` no longer allows `replace_triggers_refs = []`. Removed from the 8 resources that had it.
* `azapi_response_export_values` needs the attribute present, so the maintenance configuration assignment now sets `response_export_values = []`.

Three rules are turned off in the override files, each with a comment saying when to turn it back on:

* `provider_azurerm_disallowed` flags all 140 remaining azurerm resources plus the 21 examples. It can't be satisfied until the migration finishes removing the provider.
* `azapi_resource_tag` wants exactly `tags = var.tags`. Disks, interfaces, public IPs, extensions and key vault secrets all support per-resource tag overrides, so complying would drop a documented input. That call is better made deliberately once the migration is done.
* `no_entire_resource_output_tffr2` flags the raw `*_azapi` outputs, which exist on purpose as escape hatches. It's a SHOULD.

Lint evaluates each scope separately, so the suppressions need four files: repo root, examples, and the extension and run-command submodules. The backup submodule doesn't need one because it has no azurerm resources.

## Alternative considered

Pinning `avm-authoring-version` to 0.9.5. It doesn't work. Every command calls `Test-AvmModuleVersion`, including `avm version`, which the workflow runs first in every job. With 0.10.1 published, a pinned 0.9.5 fails immediately:

```
NotInstalled: AVM upgrade required.
Installed version: 0.9.5   Latest version: 0.10.1
```

That attempt is closed in #393.

## Test results

| Check | Before | After |
|---|---|---|
| `avm lint` (0.10.1) | 155 errors | pass |
| `avm pre-commit` | pass | pass |
| `avm test unit` | 46 passed | 46 passed |

No behaviour changes. Removing an empty `replace_triggers_refs` and adding an empty `response_export_values` both match what the provider already does.

## Type of Change

- [x] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

> [!NOTE]
> Replaces #393. #392 has since merged, and this branch is rebased onto it.
