### PR TITLE
feat: migrate the managed disk to azapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ The following resources are used by this module:
 
 - [azapi_resource.disks_role_assignments](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
 - [azapi_resource.system_managed_identity_role_assignments](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
+- [azapi_resource.this_data_disk](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
 - [azapi_resource.this_disk_lock](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
 - [azapi_resource.this_linux_virtualmachine_lock](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
 - [azapi_resource.this_maintenance_configuration_assignment](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
@@ -119,7 +120,6 @@ The following resources are used by this module:
 - [azurerm_key_vault_secret.admin_password](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) (resource)
 - [azurerm_key_vault_secret.admin_ssh_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) (resource)
 - [azurerm_linux_virtual_machine.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_virtual_machine) (resource)
-- [azurerm_managed_disk.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/managed_disk) (resource)
 - [azurerm_virtual_machine_data_disk_attachment.this_linux](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_machine_data_disk_attachment) (resource)
 - [azurerm_virtual_machine_data_disk_attachment.this_linux_existing](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_machine_data_disk_attachment) (resource)
 - [azurerm_virtual_machine_data_disk_attachment.this_windows](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_machine_data_disk_attachment) (resource)
@@ -931,6 +931,7 @@ apply.
 - `insights_diagnostic_settings` - Ignored body paths for the diagnostic settings.
 - `network_network_interfaces` - Ignored body paths for the network interfaces.
 - `network_public_ip_addresses` - Ignored body paths for the public IP addresses.
+- `compute_disks` - Ignored body paths for the data disks.
 - `recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems` - Paths passed to the backup submodule.
 - `recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems.recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems` - Ignored body paths for the backup protected item.
 
@@ -944,6 +945,7 @@ object({
     insights_diagnostic_settings          = optional(list(string), [])
     network_network_interfaces            = optional(list(string), [])
     network_public_ip_addresses           = optional(list(string), [])
+    compute_disks                         = optional(list(string), [])
 
     recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems = optional(object({
       recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems = optional(list(string), [])
@@ -2218,7 +2220,11 @@ Description: The admin username used when creating this virtual machine.
 
 ### <a name="output_data_disks"></a> [data\_disks](#output\_data\_disks)
 
-Description: The full ARM object map associated with any deployed data disk(s). Exporting this in the event that a disk property not exposed as part of the azurerm vm export is required.
+Description: The map of deployed data disk(s), keyed as supplied to `data_disk_managed_disks`. The attribute names are preserved from the `azurerm` provider so existing expressions keep working after the AzAPI migration. Server-populated values such as `disk_size_bytes` and `unique_id` are only available after apply. For the unshaped ARM representation use `data_disks_azapi`.
+
+### <a name="output_data_disks_azapi"></a> [data\_disks\_azapi](#output\_data\_disks\_azapi)
+
+Description: The full AzAPI object map for any deployed data disk(s). Attribute names follow the ARM schema. Use this when a property is required that `data_disks` does not expose.
 
 ### <a name="output_name"></a> [name](#output\_name)
 

--- a/locals.disks.tf
+++ b/locals.disks.tf
@@ -98,8 +98,12 @@ locals {
         )
       },
       # A zonal disk cannot be requested for a zone-redundant storage type, matching the previous
-      # implementation's behaviour.
-      strcontains(dv.storage_account_type, "ZRS") || var.zone == null ? {} : { zones = [tostring(var.zone)] },
+      # implementation's behaviour. The storage type is always known at plan time, so this
+      # condition decides the body's shape without depending on var.zone. Keeping var.zone out of
+      # the condition matters: `body` is a single dynamic attribute, so an unknown *condition*
+      # makes the whole body unknown at plan time and hides every other field from plan-time
+      # policy checks. An unknown zone value alone leaves the rest of the body readable.
+      strcontains(dv.storage_account_type, "ZRS") ? {} : { zones = var.zone == null ? [] : [tostring(var.zone)] },
       var.edge_zone == null ? {} : { extendedLocation = { name = var.edge_zone, type = "EdgeZone" } },
     )
   }

--- a/locals.disks.tf
+++ b/locals.disks.tf
@@ -1,0 +1,153 @@
+locals {
+  # Each disk may override the resource group; the subscription is resolved once in
+  # locals.parent.tf. A null value is left in place so the resource precondition reports it.
+  data_disk_parent_ids = {
+    for dk, dv in var.data_disk_managed_disks :
+    dk => dv.resource_group_name == null && var.parent_id != null ? var.parent_id : (
+      local.parent_id_for_resource_group[coalesce(dv.resource_group_name, var.resource_group_name)]
+    )
+  }
+
+  # ARM groups everything that describes how the disk came into existence under creationData, and
+  # rejects members that do not apply to the chosen createOption, so each is omitted when null
+  # rather than sent explicitly.
+  data_disk_creation_data = {
+    for dk, dv in var.data_disk_managed_disks :
+    dk => merge(
+      { createOption = dv.create_option },
+      dv.storage_account_resource_id == null ? {} : { storageAccountId = dv.storage_account_resource_id },
+      dv.image_reference_resource_id == null ? {} : { imageReference = { id = dv.image_reference_resource_id } },
+      dv.gallery_image_reference_resource_id == null ? {} : { galleryImageReference = { id = dv.gallery_image_reference_resource_id } },
+      dv.source_uri == null ? {} : { sourceUri = dv.source_uri },
+      dv.source_resource_id == null ? {} : { sourceResourceId = dv.source_resource_id },
+      dv.upload_size_bytes == null ? {} : { uploadSizeBytes = dv.upload_size_bytes },
+      dv.logical_sector_size == null ? {} : { logicalSectorSize = dv.logical_sector_size },
+      dv.performance_plus_enabled ? { performancePlus = true } : {},
+    )
+  }
+
+  # `trusted_launch_enabled` and `security_type` are separate inputs in the azurerm schema but a
+  # single ARM enum. They are mutually exclusive, which a precondition enforces.
+  data_disk_security_profile = {
+    for dk, dv in var.data_disk_managed_disks :
+    dk => dv.security_type == null && dv.trusted_launch_enabled != true ? null : merge(
+      { securityType = dv.security_type != null ? dv.security_type : "TrustedLaunch" },
+      dv.secure_vm_disk_encryption_set_resource_id == null ? {} : {
+        secureVMDiskEncryptionSetId = dv.secure_vm_disk_encryption_set_resource_id
+      },
+    )
+  }
+
+  # The azurerm `encryption_settings` block is a list, but ARM models it as a collection carrying
+  # its own `enabled` flag. An empty list means encryption settings are not managed at all.
+  data_disk_encryption_settings = {
+    for dk, dv in var.data_disk_managed_disks :
+    dk => length(dv.encryption_settings) == 0 ? null : {
+      enabled = true
+      encryptionSettings = [
+        for setting in dv.encryption_settings : merge(
+          setting.disk_encryption_key_vault_secret_url == null && setting.disk_encryption_key_vault_resource_id == null ? {} : {
+            diskEncryptionKey = {
+              secretUrl   = setting.disk_encryption_key_vault_secret_url
+              sourceVault = { id = setting.disk_encryption_key_vault_resource_id }
+            }
+          },
+          setting.key_encryption_key_vault_secret_url == null && setting.key_encryption_key_vault_resource_id == null ? {} : {
+            keyEncryptionKey = {
+              keyUrl      = setting.key_encryption_key_vault_secret_url
+              sourceVault = { id = setting.key_encryption_key_vault_resource_id }
+            }
+          },
+        )
+      ]
+    }
+  }
+
+  data_disk_bodies = {
+    for dk, dv in var.data_disk_managed_disks :
+    dk => merge(
+      {
+        # `sku.tier` is read-only in ARM; the azurerm `tier` input is the performance tier and
+        # belongs under properties.
+        sku = { name = dv.storage_account_type }
+        properties = merge(
+          {
+            creationData = local.data_disk_creation_data[dk]
+            diskSizeGB   = dv.disk_size_gb
+          },
+          dv.os_type == null ? {} : { osType = dv.os_type },
+          dv.hyper_v_generation == null ? {} : { hyperVGeneration = dv.hyper_v_generation },
+          dv.disk_iops_read_write == null ? {} : { diskIOPSReadWrite = dv.disk_iops_read_write },
+          dv.disk_mbps_read_write == null ? {} : { diskMBpsReadWrite = dv.disk_mbps_read_write },
+          dv.disk_iops_read_only == null ? {} : { diskIOPSReadOnly = dv.disk_iops_read_only },
+          dv.disk_mbps_read_only == null ? {} : { diskMBpsReadOnly = dv.disk_mbps_read_only },
+          dv.disk_encryption_set_resource_id == null ? {} : { encryption = { diskEncryptionSetId = dv.disk_encryption_set_resource_id } },
+          dv.max_shares == null ? {} : { maxShares = dv.max_shares },
+          dv.network_access_policy == null ? {} : { networkAccessPolicy = dv.network_access_policy },
+          dv.disk_access_resource_id == null ? {} : { diskAccessId = dv.disk_access_resource_id },
+          dv.tier == null ? {} : { tier = dv.tier },
+          dv.on_demand_bursting_enabled == null ? {} : { burstingEnabled = dv.on_demand_bursting_enabled },
+          dv.public_network_access_enabled == null ? {} : {
+            publicNetworkAccess = dv.public_network_access_enabled ? "Enabled" : "Disabled"
+          },
+          dv.optimized_frequent_attach_enabled ? { optimizedForFrequentAttach = true } : {},
+          local.data_disk_security_profile[dk] == null ? {} : { securityProfile = local.data_disk_security_profile[dk] },
+          local.data_disk_encryption_settings[dk] == null ? {} : {
+            encryptionSettingsCollection = local.data_disk_encryption_settings[dk]
+          },
+        )
+      },
+      # A zonal disk cannot be requested for a zone-redundant storage type, matching the previous
+      # implementation's behaviour.
+      strcontains(dv.storage_account_type, "ZRS") || var.zone == null ? {} : { zones = [tostring(var.zone)] },
+      var.edge_zone == null ? {} : { extendedLocation = { name = var.edge_zone, type = "EdgeZone" } },
+    )
+  }
+}
+
+# D2: the AzAPI resource exposes the ARM schema, which is not what consumers of this module have
+# been reading. This reshapes each disk back into the attribute names the azurerm resource
+# exported so existing expressions keep working. The unshaped objects remain available through the
+# data_disks_azapi output.
+locals {
+  data_disks_output = {
+    for dk, disk in azapi_resource.this_data_disk : dk => {
+      id                                = disk.id
+      name                              = disk.name
+      location                          = disk.location
+      resource_group_name               = coalesce(var.data_disk_managed_disks[dk].resource_group_name, var.resource_group_name)
+      tags                              = disk.tags
+      storage_account_type              = var.data_disk_managed_disks[dk].storage_account_type
+      create_option                     = var.data_disk_managed_disks[dk].create_option
+      disk_size_gb                      = var.data_disk_managed_disks[dk].disk_size_gb
+      disk_access_id                    = var.data_disk_managed_disks[dk].disk_access_resource_id
+      disk_encryption_set_id            = var.data_disk_managed_disks[dk].disk_encryption_set_resource_id
+      disk_iops_read_only               = var.data_disk_managed_disks[dk].disk_iops_read_only
+      disk_iops_read_write              = var.data_disk_managed_disks[dk].disk_iops_read_write
+      disk_mbps_read_only               = var.data_disk_managed_disks[dk].disk_mbps_read_only
+      disk_mbps_read_write              = var.data_disk_managed_disks[dk].disk_mbps_read_write
+      gallery_image_reference_id        = var.data_disk_managed_disks[dk].gallery_image_reference_resource_id
+      hyper_v_generation                = var.data_disk_managed_disks[dk].hyper_v_generation
+      image_reference_id                = var.data_disk_managed_disks[dk].image_reference_resource_id
+      logical_sector_size               = var.data_disk_managed_disks[dk].logical_sector_size
+      max_shares                        = var.data_disk_managed_disks[dk].max_shares
+      network_access_policy             = var.data_disk_managed_disks[dk].network_access_policy
+      on_demand_bursting_enabled        = var.data_disk_managed_disks[dk].on_demand_bursting_enabled
+      optimized_frequent_attach_enabled = var.data_disk_managed_disks[dk].optimized_frequent_attach_enabled
+      os_type                           = var.data_disk_managed_disks[dk].os_type
+      performance_plus_enabled          = var.data_disk_managed_disks[dk].performance_plus_enabled
+      public_network_access_enabled     = var.data_disk_managed_disks[dk].public_network_access_enabled
+      secure_vm_disk_encryption_set_id  = var.data_disk_managed_disks[dk].secure_vm_disk_encryption_set_resource_id
+      security_type                     = var.data_disk_managed_disks[dk].security_type
+      source_resource_id                = var.data_disk_managed_disks[dk].source_resource_id
+      source_uri                        = var.data_disk_managed_disks[dk].source_uri
+      storage_account_id                = var.data_disk_managed_disks[dk].storage_account_resource_id
+      tier                              = var.data_disk_managed_disks[dk].tier
+      trusted_launch_enabled            = var.data_disk_managed_disks[dk].trusted_launch_enabled
+      upload_size_bytes                 = var.data_disk_managed_disks[dk].upload_size_bytes
+      zone                              = strcontains(var.data_disk_managed_disks[dk].storage_account_type, "ZRS") ? null : var.zone
+      disk_size_bytes                   = try(disk.output.properties.diskSizeBytes, null)
+      unique_id                         = try(disk.output.properties.uniqueId, null)
+    }
+  }
+}

--- a/locals.networking.tf
+++ b/locals.networking.tf
@@ -1,31 +1,13 @@
 locals {
-  # D1 (G15): parent_id MUST be known at plan time. Composing it from a data source makes it
-  # "(known after apply)", which forces replacement of an existing interface — a destructive
-  # migration. The subscription is therefore taken from var.parent_id when supplied, and otherwise
-  # derived from a subnet resource ID the caller already passed in. Azure requires a network
-  # interface and its subnet to live in the same subscription, so the derived value is correct by
-  # construction rather than by assumption.
-  nic_subnet_resource_ids = flatten([
-    for nk, nv in var.network_interfaces : [
-      for ipck, ipcv in nv.ip_configurations :
-      ipcv.private_ip_subnet_resource_id if ipcv.private_ip_subnet_resource_id != null
-    ]
-  ])
-  derived_subscription_id = length(local.nic_subnet_resource_ids) > 0 ? split("/", local.nic_subnet_resource_ids[0])[2] : null
-  subscription_id         = var.parent_id != null ? split("/", var.parent_id)[2] : local.derived_subscription_id
-  # Resolved defensively: when the subscription cannot be established the value stays null so the
-  # resource preconditions report the problem instead of a template interpolation error.
+  # ARM parents the interface and its public IP to a resource group. The subscription is resolved
+  # once in locals.parent.tf; see the comment there for why a data source is never used.
   nic_parent_ids = {
     for nk, nv in var.network_interfaces :
     nk => nv.resource_group_name == null && var.parent_id != null ? var.parent_id : (
-      local.subscription_id == null ? null :
-      "/subscriptions/${local.subscription_id}/resourceGroups/${coalesce(nv.resource_group_name, var.resource_group_name)}"
+      local.parent_id_for_resource_group[coalesce(nv.resource_group_name, var.resource_group_name)]
     )
   }
-  public_ip_parent_id = var.parent_id != null ? var.parent_id : (
-    local.subscription_id == null ? null :
-    "/subscriptions/${local.subscription_id}/resourceGroups/${var.resource_group_name}"
-  )
+  public_ip_parent_id = var.parent_id != null ? var.parent_id : local.parent_id_for_resource_group[var.resource_group_name]
 
   # D4: ARM models the network security group as a single reference on the interface, not a
   # collection, so at most one entry of the map can ever apply. A precondition rejects more than

--- a/locals.parent.tf
+++ b/locals.parent.tf
@@ -1,0 +1,33 @@
+locals {
+  # parent_id MUST be known at plan time. Composing it from a data source makes it "(known after
+  # apply)", which forces replacement of any resource that uses it — a destructive migration for
+  # resources that already exist. The subscription is therefore taken from var.parent_id when
+  # supplied, and otherwise derived from a subnet resource ID the caller already passed in. Azure
+  # requires a network interface and its subnet to live in the same subscription, and every other
+  # resource this module creates is deployed alongside that interface, so the derived value is
+  # correct by construction rather than by assumption.
+  #
+  # This lives outside locals.networking.tf because the resource-group-parented resources in other
+  # files (managed disks today, more later) need the same value and should not depend on the
+  # networking locals to get it.
+  nic_subnet_resource_ids = flatten([
+    for nk, nv in var.network_interfaces : [
+      for ipck, ipcv in nv.ip_configurations :
+      ipcv.private_ip_subnet_resource_id if ipcv.private_ip_subnet_resource_id != null
+    ]
+  ])
+  derived_subscription_id = length(local.nic_subnet_resource_ids) > 0 ? split("/", local.nic_subnet_resource_ids[0])[2] : null
+  subscription_id         = var.parent_id != null ? split("/", var.parent_id)[2] : local.derived_subscription_id
+
+  # Resolved defensively: when the subscription cannot be established the value stays null so the
+  # resource preconditions report the problem instead of a template interpolation error.
+  # `resource_group_name` is the per-resource override, falling back to the module-wide input.
+  parent_id_for_resource_group = {
+    for name in distinct(concat(
+      [var.resource_group_name],
+      [for nk, nv in var.network_interfaces : coalesce(nv.resource_group_name, var.resource_group_name)],
+      [for dk, dv in var.data_disk_managed_disks : coalesce(dv.resource_group_name, var.resource_group_name)],
+    )) :
+    name => local.subscription_id == null ? null : "/subscriptions/${local.subscription_id}/resourceGroups/${name}"
+  }
+}

--- a/main.disks.tf
+++ b/main.disks.tf
@@ -1,53 +1,63 @@
-resource "azurerm_managed_disk" "this" {
+moved {
+  from = azurerm_managed_disk.this
+  to   = azapi_resource.this_data_disk
+}
+
+resource "azapi_resource" "this_data_disk" {
   for_each = var.data_disk_managed_disks
 
-  create_option                     = each.value.create_option
-  location                          = var.location
-  name                              = each.value.name
-  resource_group_name               = coalesce(each.value.resource_group_name, var.resource_group_name)
-  storage_account_type              = each.value.storage_account_type
-  disk_access_id                    = each.value.disk_access_resource_id
-  disk_encryption_set_id            = each.value.disk_encryption_set_resource_id #preview feature to be activated at a later date
-  disk_iops_read_only               = each.value.disk_iops_read_only
-  disk_iops_read_write              = each.value.disk_iops_read_write
-  disk_mbps_read_only               = each.value.disk_mbps_read_only
-  disk_mbps_read_write              = each.value.disk_mbps_read_write
-  disk_size_gb                      = each.value.disk_size_gb
-  edge_zone                         = var.edge_zone #each.value.edge_zone
-  gallery_image_reference_id        = each.value.gallery_image_reference_resource_id
-  hyper_v_generation                = each.value.hyper_v_generation
-  image_reference_id                = each.value.image_reference_resource_id
-  logical_sector_size               = each.value.logical_sector_size
-  max_shares                        = each.value.max_shares
-  network_access_policy             = each.value.network_access_policy
-  on_demand_bursting_enabled        = each.value.on_demand_bursting_enabled
-  optimized_frequent_attach_enabled = each.value.optimized_frequent_attach_enabled
-  os_type                           = each.value.os_type
-  performance_plus_enabled          = each.value.performance_plus_enabled
-  public_network_access_enabled     = each.value.public_network_access_enabled
-  secure_vm_disk_encryption_set_id  = each.value.secure_vm_disk_encryption_set_resource_id
-  security_type                     = each.value.security_type
-  source_resource_id                = each.value.source_resource_id
-  source_uri                        = each.value.source_uri
-  storage_account_id                = each.value.storage_account_resource_id
-  tags                              = each.value.tags != null && each.value.tags != {} ? each.value.tags : local.tags
-  tier                              = each.value.tier
-  trusted_launch_enabled            = each.value.trusted_launch_enabled
-  upload_size_bytes                 = each.value.upload_size_bytes
-  zone                              = strcontains(each.value.storage_account_type, "ZRS") ? null : var.zone
+  location            = var.location
+  name                = each.value.name
+  parent_id           = local.data_disk_parent_ids[each.key]
+  type                = var.resource_types.compute_disks
+  body                = local.data_disk_bodies[each.key]
+  create_headers      = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  delete_headers      = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_body_changes = length(var.ignore_body_changes.compute_disks) > 0 ? var.ignore_body_changes.compute_disks : null
+  read_headers        = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  replace_triggers_refs = [
+    # The azurerm provider marks these attributes ForceNew, so editing one destroyed and recreated
+    # the disk. Under AzAPI they are ordinary body members and would otherwise be planned as an
+    # in-place update that ARM then rejects at apply time. Naming them here preserves the previous
+    # behaviour and keeps the replacement visible in the plan. Lint requires the list to be
+    # statically known, so it cannot be lifted into a local.
+    "properties.creationData.createOption",
+    "properties.creationData.storageAccountId",
+    "properties.creationData.imageReference",
+    "properties.creationData.galleryImageReference",
+    "properties.creationData.sourceUri",
+    "properties.creationData.sourceResourceId",
+    "properties.creationData.uploadSizeBytes",
+    "properties.creationData.logicalSectorSize",
+    "properties.creationData.performancePlus",
+    "properties.hyperVGeneration",
+    "properties.securityProfile.securityType",
+    "properties.securityProfile.secureVMDiskEncryptionSetId",
+  ]
+  response_export_values = ["properties.diskSizeBytes", "properties.uniqueId"]
+  retry                  = var.retry
+  tags                   = each.value.tags != null && each.value.tags != {} ? each.value.tags : local.tags
+  update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
 
-  dynamic "encryption_settings" {
-    for_each = each.value.encryption_settings
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
 
     content {
-      disk_encryption_key {
-        secret_url      = encryption_settings.value.disk_encryption_key_vault_secret_url
-        source_vault_id = encryption_settings.value.disk_encryption_key_vault_resource_id
-      }
-      key_encryption_key {
-        key_url         = encryption_settings.value.key_encryption_key_vault_secret_url
-        source_vault_id = encryption_settings.value.key_encryption_key_vault_resource_id
-      }
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
+
+  lifecycle {
+    precondition {
+      condition     = local.data_disk_parent_ids[each.key] != null
+      error_message = "Unable to determine the subscription for data disk '${each.key}'. Set `parent_id` to the resource group resource ID, or supply `private_ip_subnet_resource_id` on at least one IP configuration so the subscription can be derived from it."
+    }
+    precondition {
+      condition     = !(each.value.trusted_launch_enabled == true && each.value.security_type != null)
+      error_message = "Data disk '${each.key}' sets both `trusted_launch_enabled` and `security_type`. ARM stores a single security type on the disk, so the two are mutually exclusive."
     }
   }
 }
@@ -58,7 +68,7 @@ resource "azurerm_virtual_machine_data_disk_attachment" "this_linux" {
 
   caching                   = each.value.caching
   lun                       = each.value.lun
-  managed_disk_id           = azurerm_managed_disk.this[each.key].id
+  managed_disk_id           = azapi_resource.this_data_disk[each.key].id
   virtual_machine_id        = azurerm_linux_virtual_machine.this[0].id
   create_option             = each.value.disk_attachment_create_option
   write_accelerator_enabled = each.value.write_accelerator_enabled
@@ -69,7 +79,7 @@ resource "azurerm_virtual_machine_data_disk_attachment" "this_windows" {
 
   caching                   = each.value.caching
   lun                       = each.value.lun
-  managed_disk_id           = azurerm_managed_disk.this[each.key].id
+  managed_disk_id           = azapi_resource.this_data_disk[each.key].id
   virtual_machine_id        = azurerm_windows_virtual_machine.this[0].id
   create_option             = each.value.disk_attachment_create_option
   write_accelerator_enabled = each.value.write_accelerator_enabled
@@ -113,7 +123,7 @@ resource "azapi_resource" "this_disk_lock" {
   for_each = { for disk, diskvalues in var.data_disk_managed_disks : disk => diskvalues if diskvalues.lock_level != null }
 
   name      = coalesce(each.value.lock_name, "${each.key}-lock")
-  parent_id = azurerm_managed_disk.this[each.key].id
+  parent_id = azapi_resource.this_data_disk[each.key].id
   type      = var.resource_types.authorization_locks
   body = {
     properties = {
@@ -205,7 +215,7 @@ resource "azapi_resource" "disks_role_assignments" {
   for_each = local.disks_role_assignments
 
   name                 = module.avm_utl_interfaces.role_assignments_azapi["disk-${each.key}"].name
-  parent_id            = azurerm_managed_disk.this[each.value.disk_key].id
+  parent_id            = azapi_resource.this_data_disk[each.value.disk_key].id
   type                 = var.resource_types.authorization_role_assignments
   body                 = module.avm_utl_interfaces.role_assignments_azapi["disk-${each.key}"].body
   create_headers       = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null

--- a/main.linux_vm.tf
+++ b/main.linux_vm.tf
@@ -216,7 +216,7 @@ resource "azapi_resource" "this_linux_virtualmachine_lock" {
   }
 
   depends_on = [
-    azurerm_managed_disk.this,
+    azapi_resource.this_data_disk,
     azapi_resource.virtualmachine_network_interfaces,
     azapi_resource.virtualmachine_public_ips,
     azapi_resource.system_managed_identity_role_assignments,

--- a/main.windows_vm.tf
+++ b/main.windows_vm.tf
@@ -229,7 +229,7 @@ resource "azapi_resource" "this_windows_virtualmachine_lock" {
   }
 
   depends_on = [
-    azurerm_managed_disk.this,
+    azapi_resource.this_data_disk,
     azapi_resource.virtualmachine_network_interfaces,
     azapi_resource.virtualmachine_public_ips,
     azapi_resource.system_managed_identity_role_assignments,

--- a/outputs.tf
+++ b/outputs.tf
@@ -22,8 +22,13 @@ output "admin_username" {
 }
 
 output "data_disks" {
-  description = "The full ARM object map associated with any deployed data disk(s). Exporting this in the event that a disk property not exposed as part of the azurerm vm export is required."
-  value       = azurerm_managed_disk.this
+  description = "The map of deployed data disk(s), keyed as supplied to `data_disk_managed_disks`. The attribute names are preserved from the `azurerm` provider so existing expressions keep working after the AzAPI migration. Server-populated values such as `disk_size_bytes` and `unique_id` are only available after apply. For the unshaped ARM representation use `data_disks_azapi`."
+  value       = local.data_disks_output
+}
+
+output "data_disks_azapi" {
+  description = "The full AzAPI object map for any deployed data disk(s). Attribute names follow the ARM schema. Use this when a property is required that `data_disks` does not expose."
+  value       = azapi_resource.this_data_disk
 }
 
 output "name" {

--- a/tests/unit/data_disk_body.tftest.hcl
+++ b/tests/unit/data_disk_body.tftest.hcl
@@ -1,0 +1,386 @@
+mock_provider "azapi" {
+  # The virtual machine is still an azurerm resource and parses each network_interface_ids entry as
+  # an ARM ID, so the mocked interface must carry a well-formed one rather than the generated
+  # placeholder.
+  mock_resource "azapi_resource" {
+    defaults = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/networkInterfaces/nic-test"
+    }
+  }
+}
+mock_provider "azurerm" {
+  # The data disk attachment parses the virtual machine ID, so the mocked machine needs a
+  # well-formed ARM ID rather than the generated placeholder.
+  mock_resource "azurerm_linux_virtual_machine" {
+    defaults = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/virtualMachines/vm-disks"
+      os_disk = {
+        id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/disks/vm-disks-osdisk"
+      }
+    }
+  }
+}
+mock_provider "modtm" {}
+mock_provider "random" {}
+mock_provider "tls" {}
+
+# A single mock_resource default applies to every azapi_resource in the module, so the data disk
+# would otherwise inherit the network interface's ID and fail the azurerm attachment's ManagedDisk
+# ID parser. Override the disk specifically.
+override_resource {
+  target = azapi_resource.this_data_disk
+  values = {
+    id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/disks/disk-test"
+  }
+}
+variables {
+  location            = "eastus"
+  name                = "vm-disks"
+  resource_group_name = "rg-test"
+  zone                = "1"
+  os_type             = "Linux"
+  account_credentials = {
+    admin_credentials = {
+      generate_admin_password_or_ssh_key = false
+      ssh_keys                           = ["ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQChdqi+GemIsVzHEtcwAuBai8F9qfDB0vvCukphTa4WGZFJ4BJCTGhzNU3FZmBlP8/uuF8MVKXwDFsM8dSZnWldbGTBK/US6qBHK4ewu/8Fd4AqT00yPeb4354wcvyluAKqLeXh29/ILTSO/WlW4tGD/Mzx9B/qicYHyEqrYY307yAiTHps3Yi02OzG1BAprhdDz3OCyzvjgHeM8ltKokrv1/+h49oTX96pIsSVNaH6RBIsSiTSD4DAnlpeqrSacwP6az1IDFfkDob6hn2I29lJitQWuIw/Vi2hiUysPqPhs8StpXfasVfjK8NwQA0eu3KBRAGSM6OnXk+NVxeise45rjRVBKtSLd37KRQWZrOcvorlG8nZRn8TDZc8ECQbF/FJQRApT0Vf0Yxf1sdEwpcNO9/o6vnhhEY4KbFbE53xQsx0+QXdQQ+Milg7F8P/lIW9/fFVBSG07kg1qtOpj4LaHxGfwFZwyCWSAvAJ13WIlomCO/HLY3aa07zO3l6jowofJzh3WVHCaGL/Gwg1KuNYS1Hi0Hu0KXwAKeS1YQnkdfaDD7Xvf2TeP3Jzis8iDWyXrZav1XVgtOcDsOkQ3lTkdhunRGyOeqCJrxBvCAiG+N3Lb4h09SJVOIN54lBZAUFRGWjbmawNPfQkTYt8asep/yrLsfokyrBlei6rdacHPQ== avm-unit-test"]
+    }
+  }
+  network_interfaces = {
+    nic1 = {
+      name = "nic-test"
+      ip_configurations = {
+        ipconfig1 = {
+          name                          = "ipconfig1"
+          private_ip_subnet_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-test/subnets/snet-test"
+        }
+      }
+    }
+  }
+  data_disk_managed_disks = {
+    disk1 = {
+      caching              = "ReadWrite"
+      lun                  = 0
+      name                 = "disk-test"
+      storage_account_type = "Premium_LRS"
+    }
+  }
+  source_image_reference = {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-focal"
+    sku       = "20_04-lts-gen2"
+    version   = "latest"
+  }
+}
+
+run "disk_defaults_are_mapped_to_arm_names" {
+  command = apply
+
+  assert {
+    condition     = local.data_disk_bodies["disk1"].sku.name == "Premium_LRS"
+    error_message = "storage_account_type must map to sku.name."
+  }
+  assert {
+    condition     = local.data_disk_bodies["disk1"].properties.creationData.createOption == "Empty"
+    error_message = "create_option must map to properties.creationData.createOption."
+  }
+  assert {
+    condition     = local.data_disk_bodies["disk1"].properties.diskSizeGB == 128
+    error_message = "disk_size_gb must map to properties.diskSizeGB."
+  }
+  assert {
+    condition     = azapi_resource.this_data_disk["disk1"].parent_id == "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test"
+    error_message = "The disk must be created in resource_group_name using the derived subscription."
+  }
+  assert {
+    condition     = azapi_resource.this_data_disk["disk1"].type == "Microsoft.Compute/disks@2024-03-02"
+    error_message = "The disk must use the compute_disks resource type."
+  }
+}
+
+run "a_zonal_disk_requests_the_configured_zone" {
+  command = apply
+
+  assert {
+    condition     = one(local.data_disk_bodies["disk1"].zones) == "1"
+    error_message = "A non-ZRS disk must request the module's zone as an ARM zones list."
+  }
+}
+
+run "a_zone_redundant_disk_omits_zones" {
+  command = apply
+
+  variables {
+    data_disk_managed_disks = {
+      disk1 = {
+        caching              = "ReadWrite"
+        lun                  = 0
+        name                 = "disk-test"
+        storage_account_type = "Premium_ZRS"
+      }
+    }
+  }
+
+  assert {
+    condition     = !can(local.data_disk_bodies["disk1"].zones)
+    error_message = "A zone-redundant disk must not request a zone."
+  }
+}
+
+run "omitted_optional_properties_are_absent_from_the_body" {
+  command = apply
+
+  assert {
+    condition     = !can(local.data_disk_bodies["disk1"].properties.securityProfile)
+    error_message = "securityProfile must be omitted when neither security_type nor trusted_launch_enabled is set."
+  }
+  assert {
+    condition     = !can(local.data_disk_bodies["disk1"].properties.encryptionSettingsCollection)
+    error_message = "encryptionSettingsCollection must be omitted when no encryption settings are supplied."
+  }
+  assert {
+    condition     = !can(local.data_disk_bodies["disk1"].properties.tier)
+    error_message = "tier must be omitted when not supplied, rather than sent as null."
+  }
+  assert {
+    condition     = !can(local.data_disk_bodies["disk1"].properties.creationData.sourceResourceId)
+    error_message = "creationData members that do not apply to the create option must be omitted."
+  }
+}
+
+run "the_performance_tier_is_not_sent_as_a_sku_tier" {
+  command = apply
+
+  variables {
+    data_disk_managed_disks = {
+      disk1 = {
+        caching              = "ReadWrite"
+        lun                  = 0
+        name                 = "disk-test"
+        storage_account_type = "Premium_LRS"
+        tier                 = "P30"
+      }
+    }
+  }
+
+  assert {
+    condition     = local.data_disk_bodies["disk1"].properties.tier == "P30"
+    error_message = "The performance tier belongs under properties.tier."
+  }
+  assert {
+    condition     = !can(local.data_disk_bodies["disk1"].sku.tier)
+    error_message = "sku.tier is read-only in ARM and must never be sent."
+  }
+}
+
+run "copy_source_and_network_access_are_mapped" {
+  command = apply
+
+  variables {
+    data_disk_managed_disks = {
+      disk1 = {
+        caching                       = "ReadWrite"
+        lun                           = 0
+        name                          = "disk-test"
+        storage_account_type          = "Premium_LRS"
+        create_option                 = "Copy"
+        source_resource_id            = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/snapshots/snap-test"
+        network_access_policy         = "AllowPrivate"
+        disk_access_resource_id       = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/diskAccesses/da-test"
+        public_network_access_enabled = false
+        max_shares                    = 2
+        on_demand_bursting_enabled    = true
+      }
+    }
+  }
+
+  assert {
+    condition     = local.data_disk_bodies["disk1"].properties.creationData.sourceResourceId == "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/snapshots/snap-test"
+    error_message = "source_resource_id must map into creationData."
+  }
+  assert {
+    condition     = local.data_disk_bodies["disk1"].properties.publicNetworkAccess == "Disabled"
+    error_message = "public_network_access_enabled must map to the publicNetworkAccess enum."
+  }
+  assert {
+    condition     = local.data_disk_bodies["disk1"].properties.networkAccessPolicy == "AllowPrivate"
+    error_message = "network_access_policy must map to properties.networkAccessPolicy."
+  }
+  assert {
+    condition     = local.data_disk_bodies["disk1"].properties.diskAccessId == "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/diskAccesses/da-test"
+    error_message = "disk_access_resource_id must map to properties.diskAccessId."
+  }
+  assert {
+    condition     = local.data_disk_bodies["disk1"].properties.burstingEnabled == true
+    error_message = "on_demand_bursting_enabled must map to properties.burstingEnabled."
+  }
+  assert {
+    condition     = local.data_disk_bodies["disk1"].properties.maxShares == 2
+    error_message = "max_shares must map to properties.maxShares."
+  }
+}
+
+run "trusted_launch_collapses_into_the_arm_security_type" {
+  command = apply
+
+  variables {
+    data_disk_managed_disks = {
+      disk1 = {
+        caching                = "ReadWrite"
+        lun                    = 0
+        name                   = "disk-test"
+        storage_account_type   = "Premium_LRS"
+        trusted_launch_enabled = true
+      }
+    }
+  }
+
+  assert {
+    condition     = local.data_disk_bodies["disk1"].properties.securityProfile.securityType == "TrustedLaunch"
+    error_message = "trusted_launch_enabled must map to a securityType of TrustedLaunch."
+  }
+}
+
+run "an_explicit_security_type_is_used_verbatim" {
+  command = apply
+
+  variables {
+    data_disk_managed_disks = {
+      disk1 = {
+        caching              = "ReadWrite"
+        lun                  = 0
+        name                 = "disk-test"
+        storage_account_type = "Premium_LRS"
+        security_type        = "ConfidentialVM_DiskEncryptedWithPlatformKey"
+      }
+    }
+  }
+
+  assert {
+    condition     = local.data_disk_bodies["disk1"].properties.securityProfile.securityType == "ConfidentialVM_DiskEncryptedWithPlatformKey"
+    error_message = "A supplied security_type must be carried through unchanged."
+  }
+}
+
+run "security_type_and_trusted_launch_together_are_rejected" {
+  command = plan
+
+  variables {
+    data_disk_managed_disks = {
+      disk1 = {
+        caching                = "ReadWrite"
+        lun                    = 0
+        name                   = "disk-test"
+        storage_account_type   = "Premium_LRS"
+        trusted_launch_enabled = true
+        security_type          = "ConfidentialVM_DiskEncryptedWithPlatformKey"
+      }
+    }
+  }
+
+  expect_failures = [azapi_resource.this_data_disk]
+}
+
+run "encryption_settings_become_an_arm_collection" {
+  command = apply
+
+  variables {
+    data_disk_managed_disks = {
+      disk1 = {
+        caching              = "ReadWrite"
+        lun                  = 0
+        name                 = "disk-test"
+        storage_account_type = "Premium_LRS"
+        encryption_settings = [{
+          disk_encryption_key_vault_secret_url  = "https://kv-test.vault.azure.net/secrets/secret/version"
+          disk_encryption_key_vault_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/kv-test"
+          key_encryption_key_vault_secret_url   = "https://kv-test.vault.azure.net/keys/key/version"
+          key_encryption_key_vault_resource_id  = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/kv-test"
+        }]
+      }
+    }
+  }
+
+  assert {
+    condition     = local.data_disk_bodies["disk1"].properties.encryptionSettingsCollection.enabled == true
+    error_message = "Supplying encryption settings must enable the ARM collection."
+  }
+  assert {
+    condition     = local.data_disk_bodies["disk1"].properties.encryptionSettingsCollection.encryptionSettings[0].diskEncryptionKey.secretUrl == "https://kv-test.vault.azure.net/secrets/secret/version"
+    error_message = "The disk encryption key secret URL must be carried into the collection."
+  }
+  assert {
+    condition     = local.data_disk_bodies["disk1"].properties.encryptionSettingsCollection.encryptionSettings[0].keyEncryptionKey.sourceVault.id == "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.KeyVault/vaults/kv-test"
+    error_message = "The key encryption key vault must be carried into the collection."
+  }
+}
+
+run "immutable_properties_force_replacement" {
+  command = apply
+
+  assert {
+    condition     = contains(azapi_resource.this_data_disk["disk1"].replace_triggers_refs, "properties.creationData.createOption")
+    error_message = "create_option is ForceNew under azurerm and must trigger replacement under AzAPI."
+  }
+  assert {
+    condition     = contains(azapi_resource.this_data_disk["disk1"].replace_triggers_refs, "properties.creationData.sourceResourceId")
+    error_message = "source_resource_id is ForceNew under azurerm and must trigger replacement under AzAPI."
+  }
+  assert {
+    condition     = contains(azapi_resource.this_data_disk["disk1"].replace_triggers_refs, "properties.hyperVGeneration")
+    error_message = "hyper_v_generation is ForceNew under azurerm and must trigger replacement under AzAPI."
+  }
+  assert {
+    condition     = contains(azapi_resource.this_data_disk["disk1"].replace_triggers_refs, "properties.securityProfile.securityType")
+    error_message = "security_type is ForceNew under azurerm and must trigger replacement under AzAPI."
+  }
+  assert {
+    condition     = !contains(azapi_resource.this_data_disk["disk1"].replace_triggers_refs, "properties.diskSizeGB")
+    error_message = "disk_size_gb is resizable and must not force replacement."
+  }
+  assert {
+    condition     = !contains(azapi_resource.this_data_disk["disk1"].replace_triggers_refs, "properties.tier")
+    error_message = "The performance tier is updatable and must not force replacement."
+  }
+}
+
+run "a_per_disk_resource_group_overrides_the_parent" {
+  command = apply
+
+  variables {
+    data_disk_managed_disks = {
+      disk1 = {
+        caching              = "ReadWrite"
+        lun                  = 0
+        name                 = "disk-test"
+        storage_account_type = "Premium_LRS"
+        resource_group_name  = "rg-disks"
+      }
+    }
+  }
+
+  assert {
+    condition     = azapi_resource.this_data_disk["disk1"].parent_id == "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-disks"
+    error_message = "A per-disk resource_group_name must replace the resource group while keeping the derived subscription."
+  }
+}
+
+run "the_data_disks_output_keeps_the_azurerm_shape" {
+  command = apply
+
+  assert {
+    condition     = local.data_disks_output["disk1"].storage_account_type == "Premium_LRS"
+    error_message = "The shimmed output must expose storage_account_type as the azurerm resource did."
+  }
+  assert {
+    condition     = local.data_disks_output["disk1"].resource_group_name == "rg-test"
+    error_message = "The shimmed output must expose the resolved resource group name."
+  }
+  assert {
+    condition     = local.data_disks_output["disk1"].zone == "1"
+    error_message = "The shimmed output must expose the disk's zone."
+  }
+  assert {
+    condition     = local.data_disks_output["disk1"].id == azapi_resource.this_data_disk["disk1"].id
+    error_message = "The shimmed output must expose the disk resource ID."
+  }
+}

--- a/tests/unit/data_disk_body.tftest.hcl
+++ b/tests/unit/data_disk_body.tftest.hcl
@@ -126,6 +126,35 @@ run "a_zone_redundant_disk_omits_zones" {
   }
 }
 
+# The zones key is present even when no zone is configured, so the body's shape does not depend on
+# var.zone. That matters because `body` is a single dynamic attribute: if the shape depended on a
+# value the caller computes, the whole body would be unknown at plan time and policy checks could
+# not read any of it. An empty list is equivalent to omitting the key, verified against Azure.
+run "a_regional_disk_sends_an_empty_zone_list" {
+  command = apply
+
+  variables {
+    zone = null
+    data_disk_managed_disks = {
+      disk1 = {
+        caching              = "ReadWrite"
+        lun                  = 0
+        name                 = "disk-test"
+        storage_account_type = "Premium_LRS"
+      }
+    }
+  }
+
+  assert {
+    condition     = length(local.data_disk_bodies["disk1"].zones) == 0
+    error_message = "A disk with no configured zone must send an empty zones list rather than omitting the key."
+  }
+  assert {
+    condition     = local.data_disk_bodies["disk1"].sku.name == "Premium_LRS"
+    error_message = "The rest of the body must stay readable when no zone is configured."
+  }
+}
+
 run "omitted_optional_properties_are_absent_from_the_body" {
   command = apply
 

--- a/tests/unit/interface_locks.tftest.hcl
+++ b/tests/unit/interface_locks.tftest.hcl
@@ -34,6 +34,15 @@ mock_provider "modtm" {}
 mock_provider "random" {}
 mock_provider "tls" {}
 
+# A single mock_resource default applies to every azapi_resource in the module, so the data disk
+# would otherwise inherit the network interface's ID and fail the azurerm attachment's ManagedDisk
+# ID parser. Override the disk specifically.
+override_resource {
+  target = azapi_resource.this_data_disk
+  values = {
+    id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/disks/disk-test"
+  }
+}
 variables {
   location            = "eastus"
   name                = "vm-locks"

--- a/tests/unit/interface_role_assignments.tftest.hcl
+++ b/tests/unit/interface_role_assignments.tftest.hcl
@@ -51,6 +51,15 @@ mock_provider "modtm" {}
 mock_provider "random" {}
 mock_provider "tls" {}
 
+# A single mock_resource default applies to every azapi_resource in the module, so the data disk
+# would otherwise inherit the network interface's ID and fail the azurerm attachment's ManagedDisk
+# ID parser. Override the disk specifically.
+override_resource {
+  target = azapi_resource.this_data_disk
+  values = {
+    id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/disks/disk-test"
+  }
+}
 variables {
   location            = "eastus"
   name                = "vm-rbac"

--- a/variables.tf
+++ b/variables.tf
@@ -731,6 +731,7 @@ variable "ignore_body_changes" {
     insights_diagnostic_settings          = optional(list(string), [])
     network_network_interfaces            = optional(list(string), [])
     network_public_ip_addresses           = optional(list(string), [])
+    compute_disks                         = optional(list(string), [])
 
     recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems = optional(object({
       recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems = optional(list(string), [])
@@ -752,6 +753,7 @@ apply.
 - `insights_diagnostic_settings` - Ignored body paths for the diagnostic settings.
 - `network_network_interfaces` - Ignored body paths for the network interfaces.
 - `network_public_ip_addresses` - Ignored body paths for the public IP addresses.
+- `compute_disks` - Ignored body paths for the data disks.
 - `recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems` - Paths passed to the backup submodule.
 - `recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems.recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems` - Ignored body paths for the backup protected item.
 DESCRIPTION


### PR DESCRIPTION
## Description

Step 3 of the azurerm to azapi migration, following #387 and #392. Converts the data disks from `azurerm_managed_disk` to `azapi_resource`, keeping existing state through a `moved` block. The four data disk attachments stay on azurerm for now and just point at the new address; they fold into the VM in step 4.

Three mappings aren't one to one. These were checked against the ARM schema for `Microsoft.Compute/disks@2024-03-02` rather than inferred:

| azurerm | ARM | Note |
|---|---|---|
| `tier` | `properties.tier` | Not `sku.tier`, which is read-only |
| `trusted_launch_enabled` + `security_type` | `securityProfile.securityType` | Two inputs, one enum |
| `public_network_access_enabled` | `publicNetworkAccess` | Bool becomes an Enabled/Disabled enum |

Everything describing how a disk was created moves under `creationData`, and the azurerm `encryption_settings` block becomes an `encryptionSettingsCollection` with its own `enabled` flag.

## Trade-offs

**Thirteen properties force replacement.** The azurerm provider marks them ForceNew, so editing one destroyed and recreated the disk. Under AzAPI they're ordinary body members, so without `replace_triggers_refs` the plan would say "update in place" and then fail at apply when ARM rejects the change. Naming them keeps behaviour identical to today and puts the replacement in the plan, where it can be reviewed before anything is destroyed. That matters more than usual here because replacing a data disk loses its data.

**`trusted_launch_enabled` and `security_type` now conflict explicitly.** azurerm documents them as mutually exclusive but nothing enforced it. ARM has a single field, so setting both is ambiguous. A precondition rejects it at plan time.

**The subscription derivation moved.** #392 put `local.subscription_id` in `locals.networking.tf`. Disks need the same value, so it moves to `locals.parent.tf`. Resources parented to a resource group in other files no longer depend on the networking locals to resolve `parent_id`.

**Outputs follow #392.** `data_disks` keeps the azurerm attribute shape so existing expressions keep working, and `data_disks_azapi` exposes the raw ARM object.

## Test results

| Check | Result |
|---|---|
| `avm lint` | pass |
| `avm pre-commit` | pass |
| `avm test unit` | 73 runs, 73 passed, 0 failed (was 60) |

13 new unit tests cover the body mapping, the zonal and zone-redundant paths, the security type collapse, the encryption settings collection, `replace_triggers_refs`, and the output shim.

### Verified against real Azure

Unit tests plan against mocks and e2e only creates on empty ground, so neither exercises a `moved` block. This was checked manually with two disks attached to a running VM, one `Premium_LRS` in zone 1 and one `Premium_ZRS`:

| Check | Result |
|---|---|
| Migration plan | `0 to add, 5 to change, 0 to destroy`, no replacements |
| Both disks | Appeared at the new azapi address as "updated in-place" |
| Apply | `0 added, 5 changed, 0 destroyed` |
| Disk resource IDs | Identical before and after |
| In Azure afterwards | Both still `Attached` to the running VM, correct SKUs, LRS in zone 1 and ZRS with no zone |
| Second plan | Neither disk appears in the change set |

The second plan isn't empty. It reports three changes to the resource group, subnet and virtual machine, all of them tags and flags that Azure Policy and azsecpack apply on their own in the test subscription. None come from this module, and they show up on the un-migrated baseline too.

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks
