### PR TITLE
feat: migrate the Linux virtual machine to azapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ The following resources are used by this module:
 - [azapi_resource.system_managed_identity_role_assignments](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
 - [azapi_resource.this_data_disk](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
 - [azapi_resource.this_disk_lock](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
+- [azapi_resource.this_linux_virtual_machine](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
 - [azapi_resource.this_linux_virtualmachine_lock](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
 - [azapi_resource.this_maintenance_configuration_assignment](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
 - [azapi_resource.this_network_interface_diagnostic_settings](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
@@ -119,7 +120,6 @@ The following resources are used by this module:
 - [azurerm_dev_test_global_vm_shutdown_schedule.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dev_test_global_vm_shutdown_schedule) (resource)
 - [azurerm_key_vault_secret.admin_password](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) (resource)
 - [azurerm_key_vault_secret.admin_ssh_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) (resource)
-- [azurerm_linux_virtual_machine.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_virtual_machine) (resource)
 - [azurerm_virtual_machine_data_disk_attachment.this_linux](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_machine_data_disk_attachment) (resource)
 - [azurerm_virtual_machine_data_disk_attachment.this_linux_existing](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_machine_data_disk_attachment) (resource)
 - [azurerm_virtual_machine_data_disk_attachment.this_windows](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_machine_data_disk_attachment) (resource)
@@ -932,6 +932,7 @@ apply.
 - `network_network_interfaces` - Ignored body paths for the network interfaces.
 - `network_public_ip_addresses` - Ignored body paths for the public IP addresses.
 - `compute_disks` - Ignored body paths for the data disks.
+- `compute_virtual_machines` - Ignored body paths for the virtual machine.
 - `recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems` - Paths passed to the backup submodule.
 - `recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems.recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems` - Ignored body paths for the backup protected item.
 
@@ -946,6 +947,7 @@ object({
     network_network_interfaces            = optional(list(string), [])
     network_public_ip_addresses           = optional(list(string), [])
     compute_disks                         = optional(list(string), [])
+    compute_virtual_machines              = optional(list(string), [])
 
     recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems = optional(object({
       recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems = optional(list(string), [])
@@ -1582,6 +1584,7 @@ sovereign cloud with older API versions, or when opting into a newer preview API
 
 - `maintenance_configuration_assignments` - Maintenance configuration assignments applied to the virtual machine.
 - `compute_disks` - The managed disk type used when updating the OS disk network access settings.
+- `compute_virtual_machines` - The virtual machine.
 - `authorization_locks` - Management locks applied to the virtual machine and its child resources.
 - `authorization_role_assignments` - Role assignments applied to the virtual machine and its child resources.
 - `insights_diagnostic_settings` - Diagnostic settings applied to the virtual machine and its OS disk.
@@ -1596,6 +1599,7 @@ Type:
 object({
     maintenance_configuration_assignments = optional(string, "Microsoft.Maintenance/configurationAssignments@2023-04-01")
     compute_disks                         = optional(string, "Microsoft.Compute/disks@2024-03-02")
+    compute_virtual_machines              = optional(string, "Microsoft.Compute/virtualMachines@2024-11-01")
     authorization_locks                   = optional(string, "Microsoft.Authorization/locks@2020-05-01")
     authorization_role_assignments        = optional(string, "Microsoft.Authorization/roleAssignments@2022-04-01")
     insights_diagnostic_settings          = optional(string, "Microsoft.Insights/diagnosticSettings@2021-05-01-preview")

--- a/examples/linux_os_managed_disk/exceptions/aprl.rego
+++ b/examples/linux_os_managed_disk/exceptions/aprl.rego
@@ -1,5 +1,10 @@
 package Azure_Proactive_Resiliency_Library_v2
 import rego.v1
+# Both rules read the SKU from the OS disk. This example attaches a disk the caller already owns,
+# and a disk's SKU belongs to the disk rather than to the machine, so the module omits the property
+# in attach mode exactly as the azurerm provider did. The second rule is the AzAPI counterpart of
+# the first and has no azurerm equivalent, which is why it only appears once the machine moves to
+# AzAPI. The disk this example attaches is Premium_LRS and does satisfy the intent of both.
 exception contains rules if {
-  rules = ["mission_critical_virtual_machine_should_use_premium_or_ultra_disks"]
+  rules = ["mission_critical_virtual_machine_should_use_premium_or_ultra_disks", "virtual_machines_should_use_managed_disks"]
 }

--- a/locals.linux_vm.tf
+++ b/locals.linux_vm.tf
@@ -1,23 +1,28 @@
 locals {
   # ARM nests the managed disk settings of the OS disk under storageProfile.osDisk.managedDisk,
   # while the azurerm schema kept them flat on the os_disk block.
+  #
+  # Every member below is written as an always-present key whose value may be null, rather than as
+  # a conditional that decides whether the key exists. A conditional keyed on a value the caller
+  # computes is unknown at plan time, and a single unknown argument makes the whole merge unknown,
+  # which hides the entire body from policy checks. Only the leaves may be unknown.
   linux_vm_os_disk_managed_disk = merge(
     var.os_disk.storage_account_type == null || var.os_disk_attach_mode ? {} : {
       storageAccountType = var.os_disk.storage_account_type
     },
-    var.os_disk.disk_encryption_set_id == null ? {} : {
-      diskEncryptionSet = { id = var.os_disk.disk_encryption_set_id }
-    },
-    var.os_disk.secure_vm_disk_encryption_set_id == null && var.os_disk.security_encryption_type == null ? {} : {
-      securityProfile = merge(
+    {
+      diskEncryptionSet = var.os_disk.disk_encryption_set_id == null ? null : { id = var.os_disk.disk_encryption_set_id }
+      securityProfile = var.os_disk.secure_vm_disk_encryption_set_id == null && var.os_disk.security_encryption_type == null ? null : merge(
         var.os_disk.security_encryption_type == null ? {} : { securityEncryptionType = var.os_disk.security_encryption_type },
-        var.os_disk.secure_vm_disk_encryption_set_id == null ? {} : {
-          diskEncryptionSet = { id = var.os_disk.secure_vm_disk_encryption_set_id }
+        {
+          diskEncryptionSet = var.os_disk.secure_vm_disk_encryption_set_id == null ? null : {
+            id = var.os_disk.secure_vm_disk_encryption_set_id
+          }
         },
       )
+      # Attaching an existing managed disk replaces the image-based create entirely.
+      id = var.os_managed_disk_id
     },
-    # Attaching an existing managed disk replaces the image-based create entirely.
-    var.os_managed_disk_id == null ? {} : { id = var.os_managed_disk_id },
   )
 
   linux_vm_os_disk = merge(
@@ -40,7 +45,7 @@ locals {
         placement = var.os_disk.diff_disk_settings.placement
       }
     },
-    length(local.linux_vm_os_disk_managed_disk) == 0 ? {} : { managedDisk = local.linux_vm_os_disk_managed_disk },
+    { managedDisk = local.linux_vm_os_disk_managed_disk },
   )
 
   # ARM groups the guest patching inputs under linuxConfiguration.patchSettings. It is only read
@@ -135,8 +140,10 @@ locals {
 
   linux_vm_gallery_applications = [
     for key, application in var.gallery_applications : merge(
-      { packageReferenceId = application.version_id },
-      application.configuration_blob_uri == null ? {} : { configurationReference = application.configuration_blob_uri },
+      {
+        packageReferenceId     = application.version_id
+        configurationReference = application.configuration_blob_uri
+      },
       application.order == null ? {} : { order = application.order },
       application.tag == null ? {} : { tags = application.tag },
     )
@@ -149,7 +156,7 @@ locals {
           hardwareProfile = { vmSize = var.sku_size }
           storageProfile = merge(
             { osDisk = local.linux_vm_os_disk },
-            local.linux_vm_image_reference == null ? {} : { imageReference = local.linux_vm_image_reference },
+            { imageReference = local.linux_vm_image_reference },
             var.disk_controller_type == null ? {} : { diskControllerType = var.disk_controller_type },
           )
           networkProfile = { networkInterfaces = local.linux_vm_network_interfaces }
@@ -158,10 +165,10 @@ locals {
         length(local.linux_vm_security_profile) == 0 ? {} : { securityProfile = local.linux_vm_security_profile },
         var.boot_diagnostics ? {
           diagnosticsProfile = {
-            bootDiagnostics = merge(
-              { enabled = true },
-              var.boot_diagnostics_storage_account_uri == null ? {} : { storageUri = var.boot_diagnostics_storage_account_uri },
-            )
+            bootDiagnostics = {
+              enabled    = true
+              storageUri = var.boot_diagnostics_storage_account_uri
+            }
           }
         } : {},
         var.vm_additional_capabilities == null ? {} : {
@@ -170,21 +177,28 @@ locals {
             var.vm_additional_capabilities.ultra_ssd_enabled == null ? {} : { ultraSSDEnabled = var.vm_additional_capabilities.ultra_ssd_enabled },
           )
         },
-        var.availability_set_resource_id == null ? {} : { availabilitySet = { id = var.availability_set_resource_id } },
-        var.capacity_reservation_group_resource_id == null ? {} : {
-          capacityReservation = { capacityReservationGroup = { id = var.capacity_reservation_group_resource_id } }
+        # Each of these is a resource id the caller routinely computes, so the key is always
+        # present and only the value varies. Deciding key presence on an unknown would make the
+        # whole properties object unknown and blind every policy check on the machine.
+        {
+          capacityReservation     = var.capacity_reservation_group_resource_id == null ? null : { capacityReservationGroup = { id = var.capacity_reservation_group_resource_id } }
+          host                    = var.dedicated_host_resource_id == null ? null : { id = var.dedicated_host_resource_id }
+          hostGroup               = var.dedicated_host_group_resource_id == null ? null : { id = var.dedicated_host_group_resource_id }
+          proximityPlacementGroup = var.proximity_placement_group_resource_id == null ? null : { id = var.proximity_placement_group_resource_id }
+          virtualMachineScaleSet  = var.virtual_machine_scale_set_resource_id == null ? null : { id = var.virtual_machine_scale_set_resource_id }
+          userData                = var.user_data
         },
-        var.dedicated_host_resource_id == null ? {} : { host = { id = var.dedicated_host_resource_id } },
-        var.dedicated_host_group_resource_id == null ? {} : { hostGroup = { id = var.dedicated_host_group_resource_id } },
-        var.proximity_placement_group_resource_id == null ? {} : { proximityPlacementGroup = { id = var.proximity_placement_group_resource_id } },
-        var.virtual_machine_scale_set_resource_id == null ? {} : { virtualMachineScaleSet = { id = var.virtual_machine_scale_set_resource_id } },
+        # availabilitySet is the exception to the rule above. Policy requires the property to be
+        # absent rather than null, so the key has to stay conditional. That is safe here: the
+        # condition is only unknown when the caller actually supplies an availability set, and a
+        # machine that does cannot satisfy the rule anyway.
+        var.availability_set_resource_id == null ? {} : { availabilitySet = { id = var.availability_set_resource_id } },
         var.priority == null ? {} : { priority = var.priority },
         var.eviction_policy == null ? {} : { evictionPolicy = var.eviction_policy },
         var.max_bid_price == null || var.max_bid_price == -1 ? {} : { billingProfile = { maxPrice = var.max_bid_price } },
         var.license_type == null ? {} : { licenseType = var.license_type },
         var.extensions_time_budget == null ? {} : { extensionsTimeBudget = var.extensions_time_budget },
         var.platform_fault_domain == null || var.platform_fault_domain == -1 ? {} : { platformFaultDomain = var.platform_fault_domain },
-        var.user_data == null ? {} : { userData = var.user_data },
         length(local.linux_vm_gallery_applications) == 0 ? {} : {
           applicationProfile = { galleryApplications = local.linux_vm_gallery_applications }
         },

--- a/locals.linux_vm.tf
+++ b/locals.linux_vm.tf
@@ -20,9 +20,12 @@ locals {
           }
         },
       )
-      # Attaching an existing managed disk replaces the image-based create entirely.
-      id = var.os_managed_disk_id
     },
+    # Attaching an existing managed disk replaces the image-based create entirely. Azure assigns
+    # this id itself for an image build, so sending it as null there would leave AzAPI tracking a
+    # path the server always fills in, and every plan would report drift. os_disk_attach_mode is a
+    # plain input rather than a computed value, so keying the presence on it is known at plan time.
+    var.os_disk_attach_mode ? { id = var.os_managed_disk_id } : {},
   )
 
   linux_vm_os_disk = merge(

--- a/locals.linux_vm.tf
+++ b/locals.linux_vm.tf
@@ -25,6 +25,10 @@ locals {
       # Attach reuses an existing disk; every other path creates one from the image.
       createOption = var.os_disk_attach_mode ? "Attach" : "FromImage"
       caching      = var.os_disk.caching
+      # The azurerm provider deleted the OS disk itself when the machine was destroyed, through
+      # the delete_os_disk_on_deletion feature that defaults to true. AzAPI has no equivalent, so
+      # ARM is asked to do it instead. A disk the caller attached stays, because they own it.
+      deleteOption = var.os_disk_attach_mode ? "Detach" : "Delete"
     },
     var.os_disk_attach_mode ? { osType = "Linux" } : {},
     var.os_disk.name == null ? {} : { name = var.os_disk.name },

--- a/locals.linux_vm.tf
+++ b/locals.linux_vm.tf
@@ -1,0 +1,237 @@
+locals {
+  # ARM nests the managed disk settings of the OS disk under storageProfile.osDisk.managedDisk,
+  # while the azurerm schema kept them flat on the os_disk block.
+  linux_vm_os_disk_managed_disk = merge(
+    var.os_disk.storage_account_type == null || var.os_disk_attach_mode ? {} : {
+      storageAccountType = var.os_disk.storage_account_type
+    },
+    var.os_disk.disk_encryption_set_id == null ? {} : {
+      diskEncryptionSet = { id = var.os_disk.disk_encryption_set_id }
+    },
+    var.os_disk.secure_vm_disk_encryption_set_id == null && var.os_disk.security_encryption_type == null ? {} : {
+      securityProfile = merge(
+        var.os_disk.security_encryption_type == null ? {} : { securityEncryptionType = var.os_disk.security_encryption_type },
+        var.os_disk.secure_vm_disk_encryption_set_id == null ? {} : {
+          diskEncryptionSet = { id = var.os_disk.secure_vm_disk_encryption_set_id }
+        },
+      )
+    },
+    # Attaching an existing managed disk replaces the image-based create entirely.
+    var.os_managed_disk_id == null ? {} : { id = var.os_managed_disk_id },
+  )
+
+  linux_vm_os_disk = merge(
+    {
+      # Attach reuses an existing disk; every other path creates one from the image.
+      createOption = var.os_disk_attach_mode ? "Attach" : "FromImage"
+      caching      = var.os_disk.caching
+    },
+    var.os_disk_attach_mode ? { osType = "Linux" } : {},
+    var.os_disk.name == null ? {} : { name = var.os_disk.name },
+    var.os_disk.disk_size_gb == null ? {} : { diskSizeGB = var.os_disk.disk_size_gb },
+    var.os_disk.write_accelerator_enabled == null ? {} : { writeAcceleratorEnabled = var.os_disk.write_accelerator_enabled },
+    var.os_disk.diff_disk_settings == null ? {} : {
+      diffDiskSettings = {
+        option    = var.os_disk.diff_disk_settings.option
+        placement = var.os_disk.diff_disk_settings.placement
+      }
+    },
+    length(local.linux_vm_os_disk_managed_disk) == 0 ? {} : { managedDisk = local.linux_vm_os_disk_managed_disk },
+  )
+
+  # ARM groups the guest patching inputs under linuxConfiguration.patchSettings.
+  linux_vm_patch_settings = var.os_disk_attach_mode ? null : merge(
+    var.patch_mode == null ? {} : { patchMode = var.patch_mode },
+    var.patch_assessment_mode == null ? {} : { assessmentMode = var.patch_assessment_mode },
+    var.patch_mode != "AutomaticByPlatform" ? {} : {
+      automaticByPlatformSettings = merge(
+        var.reboot_setting == null ? {} : { rebootSetting = var.reboot_setting },
+        { bypassPlatformSafetyChecksOnUserSchedule = coalesce(var.bypass_platform_safety_checks_on_user_schedule_enabled, false) },
+      )
+    },
+  )
+
+  # The public half of an SSH key pair is not a secret, so it stays in the ordinary body. The
+  # value may be unknown when the module generates the key, but the shape never is.
+  linux_vm_ssh_public_keys = [
+    for key in local.admin_ssh_keys : {
+      keyData = key.public_key
+      path    = "/home/${key.username}/.ssh/authorized_keys"
+    }
+  ]
+
+  linux_vm_linux_configuration = var.os_disk_attach_mode ? null : merge(
+    {
+      disablePasswordAuthentication = local.password_authentication_disabled
+    },
+    var.provision_vm_agent == null ? {} : { provisionVMAgent = var.provision_vm_agent },
+    length(local.linux_vm_ssh_public_keys) == 0 ? {} : {
+      ssh = { publicKeys = local.linux_vm_ssh_public_keys }
+    },
+    local.linux_vm_patch_settings == null || length(coalesce(local.linux_vm_patch_settings, {})) == 0 ? {} : {
+      patchSettings = local.linux_vm_patch_settings
+    },
+  )
+
+  # Key Vault certificates surfaced to the guest. ARM nests them per source vault.
+  linux_vm_os_profile_secrets = [
+    for secret in var.secrets : {
+      sourceVault = { id = secret.key_vault_id }
+      vaultCertificates = [
+        for certificate in secret.certificate : { certificateUrl = certificate.url }
+      ]
+    }
+  ]
+
+  # osProfile is rejected outright when attaching an existing OS disk, because the guest is
+  # already provisioned.
+  linux_vm_os_profile = var.os_disk_attach_mode ? null : merge(
+    {
+      adminUsername = local.admin_username
+      computerName  = coalesce(var.computer_name, var.name)
+    },
+    var.allow_extension_operations == null ? {} : { allowExtensionOperations = var.allow_extension_operations },
+    local.linux_vm_linux_configuration == null ? {} : { linuxConfiguration = local.linux_vm_linux_configuration },
+    length(local.linux_vm_os_profile_secrets) == 0 ? {} : { secrets = local.linux_vm_os_profile_secrets },
+  )
+
+  # The interface order is significant: ARM marks the first entry primary.
+  linux_vm_network_interfaces = [
+    for index, key in local.ordered_network_interface_keys : {
+      id         = azapi_resource.virtualmachine_network_interfaces[key].id
+      properties = { primary = index == 0 }
+    }
+  ]
+
+  linux_vm_image_reference = var.os_disk_attach_mode ? null : (
+    var.source_image_resource_id != null ? { id = var.source_image_resource_id } : {
+      publisher                                 = local.source_image_reference.publisher
+      offer                                     = local.source_image_reference.offer
+      sku                                       = local.source_image_reference.sku
+      version                                   = local.source_image_reference.version
+    }
+  )
+
+  linux_vm_uefi_settings = var.secure_boot_enabled == null && var.vtpm_enabled == null ? null : merge(
+    var.secure_boot_enabled == null ? {} : { secureBootEnabled = var.secure_boot_enabled },
+    var.vtpm_enabled == null ? {} : { vTpmEnabled = var.vtpm_enabled },
+  )
+
+  linux_vm_security_profile = merge(
+    var.encryption_at_host_enabled == null ? {} : { encryptionAtHost = var.encryption_at_host_enabled },
+    local.linux_vm_uefi_settings == null ? {} : { uefiSettings = local.linux_vm_uefi_settings },
+    # ARM requires a security type alongside the UEFI settings. Each conditional yields an object
+    # with a single attribute so Terraform can unify it with the empty case.
+    local.linux_vm_uefi_settings == null ? {} : {
+      securityType = var.os_disk.security_encryption_type != null ? "ConfidentialVM" : "TrustedLaunch"
+    },
+  )
+
+  linux_vm_gallery_applications = [
+    for key, application in var.gallery_applications : merge(
+      { packageReferenceId = application.version_id },
+      application.configuration_blob_uri == null ? {} : { configurationReference = application.configuration_blob_uri },
+      application.order == null ? {} : { order = application.order },
+      application.tag == null ? {} : { tags = application.tag },
+    )
+  ]
+
+  linux_vm_body = merge(
+    {
+      properties = merge(
+        {
+          hardwareProfile = { vmSize = var.sku_size }
+          storageProfile = merge(
+            { osDisk = local.linux_vm_os_disk },
+            local.linux_vm_image_reference == null ? {} : { imageReference = local.linux_vm_image_reference },
+            var.disk_controller_type == null ? {} : { diskControllerType = var.disk_controller_type },
+          )
+          networkProfile = { networkInterfaces = local.linux_vm_network_interfaces }
+        },
+        local.linux_vm_os_profile == null ? {} : { osProfile = local.linux_vm_os_profile },
+        length(local.linux_vm_security_profile) == 0 ? {} : { securityProfile = local.linux_vm_security_profile },
+        var.boot_diagnostics ? {
+          diagnosticsProfile = {
+            bootDiagnostics = merge(
+              { enabled = true },
+              var.boot_diagnostics_storage_account_uri == null ? {} : { storageUri = var.boot_diagnostics_storage_account_uri },
+            )
+          }
+        } : {},
+        var.vm_additional_capabilities == null ? {} : {
+          additionalCapabilities = merge(
+            var.vm_additional_capabilities.hibernation_enabled == null ? {} : { hibernationEnabled = var.vm_additional_capabilities.hibernation_enabled },
+            var.vm_additional_capabilities.ultra_ssd_enabled == null ? {} : { ultraSSDEnabled = var.vm_additional_capabilities.ultra_ssd_enabled },
+          )
+        },
+        var.availability_set_resource_id == null ? {} : { availabilitySet = { id = var.availability_set_resource_id } },
+        var.capacity_reservation_group_resource_id == null ? {} : {
+          capacityReservation = { capacityReservationGroup = { id = var.capacity_reservation_group_resource_id } }
+        },
+        var.dedicated_host_resource_id == null ? {} : { host = { id = var.dedicated_host_resource_id } },
+        var.dedicated_host_group_resource_id == null ? {} : { hostGroup = { id = var.dedicated_host_group_resource_id } },
+        var.proximity_placement_group_resource_id == null ? {} : { proximityPlacementGroup = { id = var.proximity_placement_group_resource_id } },
+        var.virtual_machine_scale_set_resource_id == null ? {} : { virtualMachineScaleSet = { id = var.virtual_machine_scale_set_resource_id } },
+        var.priority == null ? {} : { priority = var.priority },
+        var.eviction_policy == null ? {} : { evictionPolicy = var.eviction_policy },
+        var.max_bid_price == null || var.max_bid_price == -1 ? {} : { billingProfile = { maxPrice = var.max_bid_price } },
+        var.license_type == null ? {} : { licenseType = var.license_type },
+        var.extensions_time_budget == null ? {} : { extensionsTimeBudget = var.extensions_time_budget },
+        var.platform_fault_domain == null || var.platform_fault_domain == -1 ? {} : { platformFaultDomain = var.platform_fault_domain },
+        var.user_data == null ? {} : { userData = var.user_data },
+        length(local.linux_vm_gallery_applications) == 0 ? {} : {
+          applicationProfile = { galleryApplications = local.linux_vm_gallery_applications }
+        },
+        var.termination_notification == null ? {} : {
+          scheduledEventsProfile = {
+            terminateNotificationProfile = {
+              enable           = var.termination_notification.enabled
+              notBeforeTimeout = var.termination_notification.timeout
+            }
+          }
+        },
+      )
+    },
+    local.managed_identity_type == null ? {} : {
+      identity = merge(
+        { type = local.managed_identity_type },
+        length(var.managed_identities.user_assigned_resource_ids) == 0 ? {} : {
+          userAssignedIdentities = {
+            for id in var.managed_identities.user_assigned_resource_ids : id => {}
+          }
+        },
+      )
+    },
+    var.plan == null ? {} : {
+      plan = {
+        name      = var.plan.name
+        product   = var.plan.product
+        publisher = var.plan.publisher
+      }
+    },
+    # Only var.zone decides the value, never the shape. See locals.disks.tf for why an unknown
+    # condition would make the whole body unknown at plan time.
+    { zones = var.zone == null ? [] : [tostring(var.zone)] },
+    var.edge_zone == null ? {} : { extendedLocation = { name = var.edge_zone, type = "EdgeZone" } },
+  )
+
+  # Secrets are kept out of `body` so they are never written to state or shown in a plan. The
+  # attribute is write-only, which requires Terraform 1.11, so it is only populated when a secret
+  # is actually supplied. Consumers using SSH keys and no custom data are unaffected.
+  # Built as one osProfile object because merge is shallow: merging two objects that each nest
+  # properties.osProfile would discard the first.
+  linux_vm_sensitive_os_profile = merge(
+    local.admin_password_linux == null ? {} : { adminPassword = local.admin_password_linux },
+    var.custom_data == null ? {} : { customData = var.custom_data },
+  )
+  linux_vm_sensitive_body = length(local.linux_vm_sensitive_os_profile) == 0 ? null : {
+    properties = { osProfile = local.linux_vm_sensitive_os_profile }
+  }
+
+  # Both values are ForceNew under the azurerm provider, and ARM cannot change either in place.
+  # Hashing keeps the replacement trigger working without putting the secret itself into state.
+  linux_vm_secret_fingerprint = length(local.linux_vm_sensitive_os_profile) == 0 ? null : sha256(join("|", [
+    local.admin_password_linux == null ? "" : local.admin_password_linux,
+    var.custom_data == null ? "" : var.custom_data,
+  ]))
+}

--- a/locals.linux_vm.tf
+++ b/locals.linux_vm.tf
@@ -39,8 +39,10 @@ locals {
     length(local.linux_vm_os_disk_managed_disk) == 0 ? {} : { managedDisk = local.linux_vm_os_disk_managed_disk },
   )
 
-  # ARM groups the guest patching inputs under linuxConfiguration.patchSettings.
-  linux_vm_patch_settings = var.os_disk_attach_mode ? null : merge(
+  # ARM groups the guest patching inputs under linuxConfiguration.patchSettings. It is only read
+  # from inside linuxConfiguration, which is itself dropped in attach mode, so there is no null
+  # case here: a null would have to be unified with the object type and break the merge.
+  linux_vm_patch_settings = merge(
     var.patch_mode == null ? {} : { patchMode = var.patch_mode },
     var.patch_assessment_mode == null ? {} : { assessmentMode = var.patch_assessment_mode },
     var.patch_mode != "AutomaticByPlatform" ? {} : {
@@ -68,7 +70,7 @@ locals {
     length(local.linux_vm_ssh_public_keys) == 0 ? {} : {
       ssh = { publicKeys = local.linux_vm_ssh_public_keys }
     },
-    local.linux_vm_patch_settings == null || length(coalesce(local.linux_vm_patch_settings, {})) == 0 ? {} : {
+    length(local.linux_vm_patch_settings) == 0 ? {} : {
       patchSettings = local.linux_vm_patch_settings
     },
   )

--- a/locals.tf
+++ b/locals.tf
@@ -14,13 +14,15 @@ locals {
     ]
   ]) : "${ra.disk_key}-${ra.ra_key}" => ra }
   linux_virtual_machine_output_map = (lower(var.os_type) == "linux") ? {
-    id                   = azurerm_linux_virtual_machine.this[0].id
-    identity             = azurerm_linux_virtual_machine.this[0].identity
-    private_ip_address   = azurerm_linux_virtual_machine.this[0].private_ip_address
-    private_ip_addresses = azurerm_linux_virtual_machine.this[0].private_ip_addresses
-    public_ip_address    = azurerm_linux_virtual_machine.this[0].public_ip_address
-    public_ip_addresses  = azurerm_linux_virtual_machine.this[0].public_ip_addresses
-    virtual_machine_id   = azurerm_linux_virtual_machine.this[0].virtual_machine_id
+    id = azapi_resource.this_linux_virtual_machine[0].id
+    # ARM returns the identity block directly. The azurerm provider exposed it as a single-element
+    # list, so the shape is preserved here.
+    identity             = local.linux_vm_identity_output
+    private_ip_address   = local.virtual_machine_private_ip_address
+    private_ip_addresses = local.virtual_machine_private_ip_addresses
+    public_ip_address    = local.virtual_machine_public_ip_address
+    public_ip_addresses  = local.virtual_machine_public_ip_addresses
+    virtual_machine_id   = try(azapi_resource.this_linux_virtual_machine[0].output.properties.vmId, null)
   } : null
   #set the type value for the managed identity that is used by azurerm
   managed_identity_type = var.managed_identities.system_assigned ? ((length(var.managed_identities.user_assigned_resource_ids) > 0) ? "SystemAssigned, UserAssigned" : "SystemAssigned") : ((length(var.managed_identities.user_assigned_resource_ids) > 0) ? "UserAssigned" : null)
@@ -66,16 +68,16 @@ locals {
   os_disk_is_imported = var.os_disk_attach_mode
   #the OS disk is an inline block on the vm resource rather than a separate managed disk, so its resource id is read
   #back off the created virtual machine.
-  os_disk_resource_id = (lower(var.os_type) == "windows") ? azurerm_windows_virtual_machine.this[0].os_disk[0].id : azurerm_linux_virtual_machine.this[0].os_disk[0].id
+  os_disk_resource_id = (lower(var.os_type) == "windows") ? azurerm_windows_virtual_machine.this[0].os_disk[0].id : try(azapi_resource.this_linux_virtual_machine[0].output.properties.storageProfile.osDisk.managedDisk.id, null)
   #concat the input variable with the simple list going forward - this is a placeholder so that we can continue to reference the local source image reference value when it includes the simpleOS option.
   source_image_reference = var.source_image_reference
   #get the first system managed identity id if it is provisioned and depending on whether the vm type is linux or windows
-  system_managed_identity_id = var.managed_identities.system_assigned ? ((lower(var.os_type) == "windows") ? azurerm_windows_virtual_machine.this[0].identity[0].principal_id : azurerm_linux_virtual_machine.this[0].identity[0].principal_id) : null
+  system_managed_identity_id = var.managed_identities.system_assigned ? ((lower(var.os_type) == "windows") ? azurerm_windows_virtual_machine.this[0].identity[0].principal_id : try(azapi_resource.this_linux_virtual_machine[0].output.identity.principalId, null)) : null
   #merge the resource group tags if tag inheritance is on.  Add this back in if agreed, passing through the resource tags for now.
   #tags = var.inherit_tags ? merge(data.azurerm_resource_group.virtualmachine_deployment.tags, var.tags) : var.tags
   tags = var.tags
   #get the vm id value depending on whether the vm is linux or windows
-  virtualmachine_resource_id = (lower(var.os_type) == "windows") ? azurerm_windows_virtual_machine.this[0].id : azurerm_linux_virtual_machine.this[0].id
+  virtualmachine_resource_id = (lower(var.os_type) == "windows") ? azurerm_windows_virtual_machine.this[0].id : azapi_resource.this_linux_virtual_machine[0].id
   windows_virtual_machine_output_map = (lower(var.os_type) == "windows") ? {
     id                   = azurerm_windows_virtual_machine.this[0].id
     identity             = azurerm_windows_virtual_machine.this[0].identity

--- a/locals.vm_outputs.tf
+++ b/locals.vm_outputs.tf
@@ -1,0 +1,45 @@
+locals {
+  # The azurerm virtual machine resource exposed private_ip_address, private_ip_addresses,
+  # public_ip_address and public_ip_addresses as computed attributes. ARM does not return any of
+  # them on the virtual machine; the azurerm provider derived them by reading the attached network
+  # interfaces. These locals reproduce that derivation from the interface resources so the
+  # virtual_machine_azurerm output keeps working after the migration.
+  #
+  # The interface order matters: azurerm reported the primary interface's primary IP configuration
+  # as the singular address, so ordered_network_interface_keys drives the ordering here too.
+  virtual_machine_ip_configurations = flatten([
+    for key in local.ordered_network_interface_keys : [
+      for config in try(azapi_resource.virtualmachine_network_interfaces[key].output.properties.ipConfigurations, []) : {
+        nic_key            = key
+        primary            = try(config.properties.primary, false)
+        private_ip_address = try(config.properties.privateIPAddress, null)
+        public_ip_id       = try(config.properties.publicIPAddress.id, null)
+      }
+    ]
+  ])
+
+  virtual_machine_private_ip_addresses = [
+    for config in local.virtual_machine_ip_configurations :
+    config.private_ip_address if config.private_ip_address != null
+  ]
+  virtual_machine_private_ip_address = try(local.virtual_machine_private_ip_addresses[0], null)
+
+  # A public IP's address is only known once the public IP resource itself is read back, so the
+  # addresses are taken from the public IP resources rather than the interface body.
+  virtual_machine_public_ip_addresses = [
+    for key, pip in azapi_resource.virtualmachine_public_ips :
+    pip.output.properties.ipAddress if try(pip.output.properties.ipAddress, null) != null
+  ]
+  virtual_machine_public_ip_address = try(local.virtual_machine_public_ip_addresses[0], null)
+
+  # azurerm modelled identity as a single-element list of objects. ARM returns one object, so it is
+  # wrapped to preserve the shape consumers already index into.
+  linux_vm_identity_output = local.managed_identity_type == null ? [] : [
+    {
+      type         = local.managed_identity_type
+      principal_id = try(azapi_resource.this_linux_virtual_machine[0].output.identity.principalId, null)
+      tenant_id    = try(azapi_resource.this_linux_virtual_machine[0].output.identity.tenantId, null)
+      identity_ids = var.managed_identities.user_assigned_resource_ids
+    }
+  ]
+}

--- a/main.disks.tf
+++ b/main.disks.tf
@@ -69,7 +69,7 @@ resource "azurerm_virtual_machine_data_disk_attachment" "this_linux" {
   caching                   = each.value.caching
   lun                       = each.value.lun
   managed_disk_id           = azapi_resource.this_data_disk[each.key].id
-  virtual_machine_id        = azurerm_linux_virtual_machine.this[0].id
+  virtual_machine_id        = azapi_resource.this_linux_virtual_machine[0].id
   create_option             = each.value.disk_attachment_create_option
   write_accelerator_enabled = each.value.write_accelerator_enabled
 }
@@ -92,7 +92,7 @@ resource "azurerm_virtual_machine_data_disk_attachment" "this_linux_existing" {
   caching                   = each.value.caching
   lun                       = each.value.lun
   managed_disk_id           = each.value.managed_disk_resource_id
-  virtual_machine_id        = azurerm_linux_virtual_machine.this[0].id
+  virtual_machine_id        = azapi_resource.this_linux_virtual_machine[0].id
   create_option             = each.value.disk_attachment_create_option
   write_accelerator_enabled = each.value.write_accelerator_enabled
 }
@@ -153,7 +153,7 @@ resource "azapi_resource" "this_disk_lock" {
     azurerm_virtual_machine_data_disk_attachment.this_linux,
     azurerm_virtual_machine_data_disk_attachment.this_windows,
     azurerm_windows_virtual_machine.this,
-    azurerm_linux_virtual_machine.this
+    azapi_resource.this_linux_virtual_machine
   ]
 }
 
@@ -200,7 +200,7 @@ resource "azapi_resource" "this_os_disk_lock" {
     azurerm_virtual_machine_data_disk_attachment.this_linux,
     azurerm_virtual_machine_data_disk_attachment.this_windows,
     azurerm_windows_virtual_machine.this,
-    azurerm_linux_virtual_machine.this,
+    azapi_resource.this_linux_virtual_machine,
     module.extension
   ]
 }

--- a/main.linux_vm.tf
+++ b/main.linux_vm.tf
@@ -20,6 +20,12 @@ resource "azapi_resource" "this_linux_virtual_machine" {
     # changed in place by ARM. They live in sensitive_body, which is write-only and therefore
     # invisible to the plan, so a hash stands in for them here. See locals.linux_vm.tf.
     local.linux_vm_secret_fingerprint,
+    # Azure names the OS disk and assigns its resource id when the machine is built from an image,
+    # so those values are present in the body adopted by the moved block but absent from the body
+    # this module sends. Watching the body paths would read that as an immutable change and
+    # replace an adopted machine, so the inputs behind them are watched instead.
+    var.os_disk.name,
+    var.os_managed_disk_id,
   ]
   replace_triggers_refs = [
     # Every path the azurerm provider marked ForceNew. Under AzAPI these are ordinary body
@@ -31,9 +37,7 @@ resource "azapi_resource" "this_linux_virtual_machine" {
     "properties.osProfile.linuxConfiguration.provisionVMAgent",
     "properties.osProfile.linuxConfiguration.ssh",
     "properties.storageProfile.imageReference",
-    "properties.storageProfile.osDisk.name",
     "properties.storageProfile.osDisk.diffDiskSettings",
-    "properties.storageProfile.osDisk.managedDisk.id",
     "properties.storageProfile.osDisk.managedDisk.storageAccountType",
     "properties.storageProfile.osDisk.managedDisk.securityProfile",
     "properties.securityProfile.uefiSettings",

--- a/main.linux_vm.tf
+++ b/main.linux_vm.tf
@@ -1,171 +1,75 @@
-resource "azurerm_linux_virtual_machine" "this" {
+moved {
+  from = azurerm_linux_virtual_machine.this
+  to   = azapi_resource.this_linux_virtual_machine
+}
+
+resource "azapi_resource" "this_linux_virtual_machine" {
   count = (lower(var.os_type) == "linux") ? 1 : 0
 
-  location = var.location
-  name     = var.name
-  #network_interface_ids = [for interface in azapi_resource.virtualmachine_network_interfaces : interface.id]
-  network_interface_ids = [for interface in local.ordered_network_interface_keys : azapi_resource.virtualmachine_network_interfaces[interface].id]
-  resource_group_name   = var.resource_group_name
-  size                  = var.sku_size
-  #optional properties
-  admin_password = local.os_disk_is_imported ? null : (local.password_authentication_disabled ? null : local.admin_password_linux)
-  #required properties (admin_username is null when using os_managed_disk_id per Provider ExactlyOneOf constraint)
-  admin_username                                         = local.admin_username
-  allow_extension_operations                             = local.os_disk_is_imported ? null : var.allow_extension_operations
-  availability_set_id                                    = var.availability_set_resource_id
-  bypass_platform_safety_checks_on_user_schedule_enabled = local.os_disk_is_imported ? null : var.bypass_platform_safety_checks_on_user_schedule_enabled
-  capacity_reservation_group_id                          = var.capacity_reservation_group_resource_id
-  computer_name                                          = local.os_disk_is_imported ? null : coalesce(var.computer_name, var.name)
-  custom_data                                            = local.os_disk_is_imported ? null : var.custom_data
-  dedicated_host_group_id                                = var.dedicated_host_group_resource_id
-  dedicated_host_id                                      = var.dedicated_host_resource_id
-  disable_password_authentication                        = local.os_disk_is_imported ? null : local.password_authentication_disabled
-  disk_controller_type                                   = var.disk_controller_type
-  edge_zone                                              = var.edge_zone
-  encryption_at_host_enabled                             = var.encryption_at_host_enabled
-  eviction_policy                                        = var.eviction_policy
-  extensions_time_budget                                 = var.extensions_time_budget
-  license_type                                           = var.license_type
-  max_bid_price                                          = var.max_bid_price
-  os_managed_disk_id                                     = var.os_managed_disk_id
-  patch_assessment_mode                                  = local.os_disk_is_imported ? null : var.patch_assessment_mode
-  patch_mode                                             = local.os_disk_is_imported ? null : var.patch_mode
-  platform_fault_domain                                  = var.platform_fault_domain
-  priority                                               = var.priority
-  provision_vm_agent                                     = local.os_disk_is_imported ? null : var.provision_vm_agent
-  proximity_placement_group_id                           = var.proximity_placement_group_resource_id
-  reboot_setting                                         = local.os_disk_is_imported ? null : var.reboot_setting
-  secure_boot_enabled                                    = var.secure_boot_enabled
-  source_image_id                                        = local.os_disk_is_imported ? null : var.source_image_resource_id
-  tags                                                   = local.tags
-  user_data                                              = var.user_data
-  virtual_machine_scale_set_id                           = var.virtual_machine_scale_set_resource_id
-  #vm_agent_platform_updates_enabled                      = var.vm_agent_platform_updates_enabled
-  vtpm_enabled = var.vtpm_enabled
-  zone         = var.zone
+  location            = var.location
+  name                = var.name
+  parent_id           = local.parent_id_for_resource_group[var.resource_group_name]
+  type                = var.resource_types.compute_virtual_machines
+  body                = local.linux_vm_body
+  create_headers      = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  delete_headers      = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_body_changes = length(var.ignore_body_changes.compute_virtual_machines) > 0 ? var.ignore_body_changes.compute_virtual_machines : null
+  read_headers        = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  replace_triggers_external_values = [
+    # admin_password and custom_data are ForceNew under the azurerm provider and cannot be
+    # changed in place by ARM. They live in sensitive_body, which is write-only and therefore
+    # invisible to the plan, so a hash stands in for them here. See locals.linux_vm.tf.
+    local.linux_vm_secret_fingerprint,
+  ]
+  replace_triggers_refs = [
+    # Every path the azurerm provider marked ForceNew. Under AzAPI these are ordinary body
+    # members, so without this an immutable edit would plan as an in-place update and then fail
+    # at apply.
+    "properties.osProfile.adminUsername",
+    "properties.osProfile.computerName",
+    "properties.osProfile.linuxConfiguration.disablePasswordAuthentication",
+    "properties.osProfile.linuxConfiguration.provisionVMAgent",
+    "properties.osProfile.linuxConfiguration.ssh",
+    "properties.storageProfile.imageReference",
+    "properties.storageProfile.osDisk.name",
+    "properties.storageProfile.osDisk.diffDiskSettings",
+    "properties.storageProfile.osDisk.managedDisk.id",
+    "properties.storageProfile.osDisk.managedDisk.storageAccountType",
+    "properties.storageProfile.osDisk.managedDisk.securityProfile",
+    "properties.securityProfile.uefiSettings",
+    "properties.availabilitySet",
+    "properties.platformFaultDomain",
+    "properties.priority",
+    "properties.evictionPolicy",
+    "plan",
+    "zones",
+    "extendedLocation",
+  ]
+  response_export_values = ["properties.vmId", "properties.storageProfile.osDisk.managedDisk.id", "identity"]
+  retry                  = var.retry
+  sensitive_body         = local.linux_vm_sensitive_body
+  tags                   = local.tags
+  update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
 
-  os_disk {
-    caching                          = var.os_disk.caching
-    storage_account_type             = local.os_disk_is_imported ? null : var.os_disk.storage_account_type
-    disk_encryption_set_id           = var.os_disk.disk_encryption_set_id
-    disk_size_gb                     = var.os_disk.disk_size_gb
-    name                             = var.os_disk.name
-    secure_vm_disk_encryption_set_id = var.os_disk.secure_vm_disk_encryption_set_id
-    security_encryption_type         = var.os_disk.security_encryption_type
-    write_accelerator_enabled        = var.os_disk.write_accelerator_enabled
-
-    dynamic "diff_disk_settings" {
-      for_each = var.os_disk.diff_disk_settings == null ? [] : ["diff_disk_settings"]
-
-      content {
-        option    = var.os_disk.diff_disk_settings.option
-        placement = var.os_disk.diff_disk_settings.placement
-      }
-    }
-  }
-
-  dynamic "additional_capabilities" {
-    for_each = var.vm_additional_capabilities == null ? [] : ["additional_capabilities"]
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
 
     content {
-      hibernation_enabled = var.vm_additional_capabilities.hibernation_enabled
-      ultra_ssd_enabled   = var.vm_additional_capabilities.ultra_ssd_enabled
-    }
-  }
-
-  dynamic "admin_ssh_key" {
-    for_each = local.os_disk_is_imported ? [] : toset(local.admin_ssh_keys)
-
-    content {
-      public_key = admin_ssh_key.value.public_key
-      username   = admin_ssh_key.value.username
-    }
-  }
-
-  dynamic "boot_diagnostics" {
-    for_each = var.boot_diagnostics ? ["boot_diagnostics"] : []
-
-    content {
-      storage_account_uri = var.boot_diagnostics_storage_account_uri
-    }
-  }
-
-  dynamic "gallery_application" {
-    for_each = { for app, app_details in var.gallery_applications : app => app_details }
-
-    content {
-      version_id             = gallery_application.value.version_id
-      configuration_blob_uri = gallery_application.value.configuration_blob_uri
-      order                  = gallery_application.value.order
-      tag                    = gallery_application.value.tag
-    }
-  }
-
-  dynamic "identity" {
-    for_each = local.managed_identity_type == null ? [] : ["identity"]
-
-    content {
-      type         = local.managed_identity_type
-      identity_ids = var.managed_identities.user_assigned_resource_ids
-    }
-  }
-
-  dynamic "plan" {
-    for_each = var.plan == null ? [] : ["plan"]
-
-    content {
-      name      = var.plan.name
-      product   = var.plan.product
-      publisher = var.plan.publisher
-    }
-  }
-
-  dynamic "secret" {
-    for_each = toset(var.secrets)
-
-    content {
-      key_vault_id = secret.value.key_vault_id
-
-      dynamic "certificate" {
-        for_each = secret.value.certificate
-
-        content {
-          url = certificate.value.url
-        }
-      }
-    }
-  }
-
-  dynamic "source_image_reference" {
-    for_each = (var.source_image_resource_id == null && !local.os_disk_is_imported) ? ["source_image_reference"] : []
-
-    content {
-      offer     = local.source_image_reference.offer
-      publisher = local.source_image_reference.publisher
-      sku       = local.source_image_reference.sku
-      version   = local.source_image_reference.version
-    }
-  }
-
-  dynamic "termination_notification" {
-    for_each = var.termination_notification == null ? [] : [
-      "termination_notification"
-    ]
-
-    content {
-      enabled = var.termination_notification.enabled
-      timeout = var.termination_notification.timeout
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
     }
   }
 
   lifecycle {
-    ignore_changes = [
-      vm_agent_platform_updates_enabled # Added property to ignore_changes as it continues to detect change in state.
-    ]
-
     precondition {
       condition     = var.os_managed_disk_id == null || var.os_disk.diff_disk_settings == null
       error_message = "The os_managed_disk_id and os_disk.diff_disk_settings are mutually exclusive. Ephemeral OS disks cannot be used when attaching an existing managed disk."
+    }
+    precondition {
+      condition     = local.parent_id_for_resource_group[var.resource_group_name] != null
+      error_message = "Unable to determine the subscription for the virtual machine. Set `parent_id` to the resource group resource ID, or supply `private_ip_subnet_resource_id` on at least one IP configuration so the subscription can be derived from it."
     }
   }
   depends_on = [ #the associations are now properties of the interface body, so the interface alone is enough.
@@ -188,7 +92,7 @@ resource "azapi_resource" "this_linux_virtualmachine_lock" {
   count = (var.lock != null) && !(lower(var.os_type) == "windows") ? 1 : 0
 
   name      = coalesce(var.lock.name, "lock-${var.lock.kind}")
-  parent_id = azurerm_linux_virtual_machine.this[0].id
+  parent_id = azapi_resource.this_linux_virtual_machine[0].id
   type      = var.resource_types.authorization_locks
   body = {
     properties = {
@@ -222,7 +126,7 @@ resource "azapi_resource" "this_linux_virtualmachine_lock" {
     azapi_resource.system_managed_identity_role_assignments,
     azurerm_virtual_machine_data_disk_attachment.this_linux,
     azurerm_virtual_machine_data_disk_attachment.this_windows,
-    azurerm_linux_virtual_machine.this,
+    azapi_resource.this_linux_virtual_machine,
     azapi_resource.this_network_interface_diagnostic_settings,
     azapi_resource.this_virtual_machine_diagnostic_settings,
     module.extension,

--- a/main.linux_vm.tf
+++ b/main.linux_vm.tf
@@ -20,26 +20,29 @@ resource "azapi_resource" "this_linux_virtual_machine" {
     # changed in place by ARM. They live in sensitive_body, which is write-only and therefore
     # invisible to the plan, so a hash stands in for them here. See locals.linux_vm.tf.
     local.linux_vm_secret_fingerprint,
-    # Azure names the OS disk and assigns its resource id when the machine is built from an image,
-    # so those values are present in the body adopted by the moved block but absent from the body
-    # this module sends. Watching the body paths would read that as an immutable change and
-    # replace an adopted machine, so the inputs behind them are watched instead.
+    # A body path may only be watched below when the module always sends a real value for it.
+    # Anything the module can omit, or send as null so that the shape of the body stays readable,
+    # differs from the body a moved block adopts from Azure and would replace the machine. The
+    # inputs behind those paths are watched here instead, and they still force replacement exactly
+    # as the azurerm provider did.
     var.os_disk.name,
     var.os_managed_disk_id,
+    var.os_disk.security_encryption_type,
+    var.os_disk.secure_vm_disk_encryption_set_id,
+    var.source_image_resource_id,
+    jsonencode(local.source_image_reference),
+    jsonencode(local.linux_vm_ssh_public_keys),
   ]
   replace_triggers_refs = [
-    # Every path the azurerm provider marked ForceNew. Under AzAPI these are ordinary body
-    # members, so without this an immutable edit would plan as an in-place update and then fail
-    # at apply.
+    # Every path the azurerm provider marked ForceNew that the module always sends a real value
+    # for. Under AzAPI these are ordinary body members, so without this an immutable edit would
+    # plan as an in-place update and then fail at apply.
     "properties.osProfile.adminUsername",
     "properties.osProfile.computerName",
     "properties.osProfile.linuxConfiguration.disablePasswordAuthentication",
     "properties.osProfile.linuxConfiguration.provisionVMAgent",
-    "properties.osProfile.linuxConfiguration.ssh",
-    "properties.storageProfile.imageReference",
     "properties.storageProfile.osDisk.diffDiskSettings",
     "properties.storageProfile.osDisk.managedDisk.storageAccountType",
-    "properties.storageProfile.osDisk.managedDisk.securityProfile",
     "properties.securityProfile.uefiSettings",
     "properties.availabilitySet",
     "properties.platformFaultDomain",

--- a/main.networking.tf
+++ b/main.networking.tf
@@ -125,7 +125,7 @@ resource "azapi_resource" "this_public_ip_lock" {
   depends_on = [
     azapi_resource.virtualmachine_network_interfaces,
     azapi_resource.virtualmachine_public_ips,
-    azurerm_linux_virtual_machine.this,
+    azapi_resource.this_linux_virtual_machine,
     azurerm_windows_virtual_machine.this
   ]
 }
@@ -169,7 +169,7 @@ resource "azapi_resource" "this_nic_lock" {
   depends_on = [
     azapi_resource.virtualmachine_network_interfaces,
     azapi_resource.virtualmachine_public_ips,
-    azurerm_linux_virtual_machine.this,
+    azapi_resource.this_linux_virtual_machine,
     azurerm_windows_virtual_machine.this
   ]
 }

--- a/main.runcommand.tf
+++ b/main.runcommand.tf
@@ -24,7 +24,7 @@ module "run_command" {
 
   depends_on = [
     azurerm_windows_virtual_machine.this,
-    azurerm_linux_virtual_machine.this,
+    azapi_resource.this_linux_virtual_machine,
     azapi_resource.this_virtual_machine_role_assignments,
     azapi_resource.system_managed_identity_role_assignments,
     module.run_command_1,
@@ -59,7 +59,7 @@ module "run_command_1" {
 
   depends_on = [
     azurerm_windows_virtual_machine.this,
-    azurerm_linux_virtual_machine.this,
+    azapi_resource.this_linux_virtual_machine,
     azapi_resource.this_virtual_machine_role_assignments,
     azapi_resource.system_managed_identity_role_assignments,
     module.extension
@@ -92,7 +92,7 @@ module "run_command_2" {
 
   depends_on = [
     azurerm_windows_virtual_machine.this,
-    azurerm_linux_virtual_machine.this,
+    azapi_resource.this_linux_virtual_machine,
     azapi_resource.this_virtual_machine_role_assignments,
     azapi_resource.system_managed_identity_role_assignments,
     module.run_command_1,

--- a/main.windows_vm.tf
+++ b/main.windows_vm.tf
@@ -235,7 +235,7 @@ resource "azapi_resource" "this_windows_virtualmachine_lock" {
     azapi_resource.system_managed_identity_role_assignments,
     azurerm_virtual_machine_data_disk_attachment.this_linux,
     azurerm_virtual_machine_data_disk_attachment.this_windows,
-    azurerm_linux_virtual_machine.this,
+    azapi_resource.this_linux_virtual_machine,
     azapi_resource.this_network_interface_diagnostic_settings,
     azapi_resource.this_virtual_machine_diagnostic_settings,
     module.extension,

--- a/outputs.tf
+++ b/outputs.tf
@@ -59,23 +59,23 @@ output "public_ips_azapi" {
 output "resource" {
   description = "The full object for the deployed virtual machine.  This is marked sensitive as it contains specific sensitive values"
   sensitive   = true
-  value       = (lower(var.os_type) == "windows") ? azurerm_windows_virtual_machine.this[0] : azurerm_linux_virtual_machine.this[0]
+  value       = (lower(var.os_type) == "windows") ? azurerm_windows_virtual_machine.this[0] : azapi_resource.this_linux_virtual_machine[0]
 }
 
 output "resource_id" {
   description = "The Azure resource id for the deployed virtual machine"
-  value       = (lower(var.os_type) == "windows") ? azurerm_windows_virtual_machine.this[0].id : azurerm_linux_virtual_machine.this[0].id
+  value       = (lower(var.os_type) == "windows") ? azurerm_windows_virtual_machine.this[0].id : azapi_resource.this_linux_virtual_machine[0].id
 }
 
 output "system_assigned_mi_principal_id" {
   description = "The principal id of the system managed identity assigned to the virtual machine"
-  value       = var.managed_identities.system_assigned == true ? ((lower(var.os_type) == "windows") ? azurerm_windows_virtual_machine.this[0].identity[0].principal_id : azurerm_linux_virtual_machine.this[0].identity[0].principal_id) : ""
+  value       = var.managed_identities.system_assigned == true ? ((lower(var.os_type) == "windows") ? azurerm_windows_virtual_machine.this[0].identity[0].principal_id : try(azapi_resource.this_linux_virtual_machine[0].output.identity.principalId, "")) : ""
 }
 
 output "virtual_machine" {
   description = "The full object for the deployed virtual machine.  This is marked sensitive as it contains specific sensitive values. This output has been duplicated to the resource output to comply with the spec and may be deprecated in the future."
   sensitive   = true
-  value       = (lower(var.os_type) == "windows") ? azurerm_windows_virtual_machine.this[0] : azurerm_linux_virtual_machine.this[0]
+  value       = (lower(var.os_type) == "windows") ? azurerm_windows_virtual_machine.this[0] : azapi_resource.this_linux_virtual_machine[0]
 }
 
 output "virtual_machine_azurerm" {

--- a/tests/unit/aad_ssh_login_extension.tftest.hcl
+++ b/tests/unit/aad_ssh_login_extension.tftest.hcl
@@ -40,6 +40,33 @@ mock_provider "random" {
 }
 mock_provider "tls" {}
 
+# The blanket azapi_resource mock gives every azapi resource the same id, which the still-azurerm
+# resources reject when they parse it as a virtual machine ID. The virtual machine also has to
+# expose an output, because the OS disk lock and network access updater read its managed disk id
+# back off the created machine.
+override_resource {
+  target = azapi_resource.this_linux_virtual_machine
+  values = {
+    id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/virtualMachines/vm-test"
+    output = {
+      identity = {
+        principalId = "11111111-1111-1111-1111-111111111111"
+        tenantId    = "22222222-2222-2222-2222-222222222222"
+      }
+      properties = {
+        vmId = "33333333-3333-3333-3333-333333333333"
+        storageProfile = {
+          osDisk = {
+            managedDisk = {
+              id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/disks/vm-test-osdisk"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
 variables {
   location            = "eastus"
   name                = "vm-aad-ssh"
@@ -134,7 +161,7 @@ run "aad_ssh_login_with_required_prerequisites" {
   }
 
   assert {
-    condition     = azurerm_linux_virtual_machine.this[0].identity[0].type == "SystemAssigned"
+    condition     = local.linux_vm_body.identity.type == "SystemAssigned"
     error_message = "The valid AAD SSH configuration must enable the VM's system-assigned managed identity."
   }
   assert {

--- a/tests/unit/backup_lifecycle.tftest.hcl
+++ b/tests/unit/backup_lifecycle.tftest.hcl
@@ -40,6 +40,33 @@ mock_provider "random" {
 }
 mock_provider "tls" {}
 
+# The blanket azapi_resource mock gives every azapi resource the same id, which the still-azurerm
+# resources reject when they parse it as a virtual machine ID. The virtual machine also has to
+# expose an output, because the OS disk lock and network access updater read its managed disk id
+# back off the created machine.
+override_resource {
+  target = azapi_resource.this_linux_virtual_machine
+  values = {
+    id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/virtualMachines/vm-test"
+    output = {
+      identity = {
+        principalId = "11111111-1111-1111-1111-111111111111"
+        tenantId    = "22222222-2222-2222-2222-222222222222"
+      }
+      properties = {
+        vmId = "33333333-3333-3333-3333-333333333333"
+        storageProfile = {
+          osDisk = {
+            managedDisk = {
+              id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/disks/vm-test-osdisk"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
 variables {
   location            = "eastus"
   name                = "vm-backup"

--- a/tests/unit/cross_subscription_app_gateway_backend_pool.tftest.hcl
+++ b/tests/unit/cross_subscription_app_gateway_backend_pool.tftest.hcl
@@ -34,6 +34,33 @@ mock_provider "random" {
 }
 mock_provider "tls" {}
 
+# The blanket azapi_resource mock gives every azapi resource the same id, which the still-azurerm
+# resources reject when they parse it as a virtual machine ID. The virtual machine also has to
+# expose an output, because the OS disk lock and network access updater read its managed disk id
+# back off the created machine.
+override_resource {
+  target = azapi_resource.this_linux_virtual_machine
+  values = {
+    id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/virtualMachines/vm-test"
+    output = {
+      identity = {
+        principalId = "11111111-1111-1111-1111-111111111111"
+        tenantId    = "22222222-2222-2222-2222-222222222222"
+      }
+      properties = {
+        vmId = "33333333-3333-3333-3333-333333333333"
+        storageProfile = {
+          osDisk = {
+            managedDisk = {
+              id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/disks/vm-test-osdisk"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
 variables {
   location            = "eastus"
   name                = "vm-cross-sub"

--- a/tests/unit/data_disk_body.tftest.hcl
+++ b/tests/unit/data_disk_body.tftest.hcl
@@ -33,6 +33,33 @@ override_resource {
     id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/disks/disk-test"
   }
 }
+# The blanket azapi_resource mock gives every azapi resource the same id, which the still-azurerm
+# resources reject when they parse it as a virtual machine ID. The virtual machine also has to
+# expose an output, because the OS disk lock and network access updater read its managed disk id
+# back off the created machine.
+override_resource {
+  target = azapi_resource.this_linux_virtual_machine
+  values = {
+    id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/virtualMachines/vm-test"
+    output = {
+      identity = {
+        principalId = "11111111-1111-1111-1111-111111111111"
+        tenantId    = "22222222-2222-2222-2222-222222222222"
+      }
+      properties = {
+        vmId = "33333333-3333-3333-3333-333333333333"
+        storageProfile = {
+          osDisk = {
+            managedDisk = {
+              id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/disks/vm-test-osdisk"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
 variables {
   location            = "eastus"
   name                = "vm-disks"

--- a/tests/unit/interface_diagnostic_settings.tftest.hcl
+++ b/tests/unit/interface_diagnostic_settings.tftest.hcl
@@ -29,6 +29,33 @@ mock_provider "modtm" {}
 mock_provider "random" {}
 mock_provider "tls" {}
 
+# The blanket azapi_resource mock gives every azapi resource the same id, which the still-azurerm
+# resources reject when they parse it as a virtual machine ID. The virtual machine also has to
+# expose an output, because the OS disk lock and network access updater read its managed disk id
+# back off the created machine.
+override_resource {
+  target = azapi_resource.this_linux_virtual_machine
+  values = {
+    id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/virtualMachines/vm-test"
+    output = {
+      identity = {
+        principalId = "11111111-1111-1111-1111-111111111111"
+        tenantId    = "22222222-2222-2222-2222-222222222222"
+      }
+      properties = {
+        vmId = "33333333-3333-3333-3333-333333333333"
+        storageProfile = {
+          osDisk = {
+            managedDisk = {
+              id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/disks/vm-test-osdisk"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
 variables {
   location            = "eastus"
   name                = "vm-diags"
@@ -89,7 +116,7 @@ run "virtual_machine_diagnostic_setting_body" {
     error_message = "The diagnostic setting must use the supplied name."
   }
   assert {
-    condition     = azapi_resource.this_virtual_machine_diagnostic_settings["vm_diags"].parent_id == "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/virtualMachines/vm-diags"
+    condition     = azapi_resource.this_virtual_machine_diagnostic_settings["vm_diags"].parent_id == azapi_resource.this_linux_virtual_machine[0].id
     error_message = "The virtual machine diagnostic setting must be parented to the virtual machine."
   }
   assert {

--- a/tests/unit/interface_locks.tftest.hcl
+++ b/tests/unit/interface_locks.tftest.hcl
@@ -43,6 +43,33 @@ override_resource {
     id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/disks/disk-test"
   }
 }
+# The blanket azapi_resource mock gives every azapi resource the same id, which the still-azurerm
+# resources reject when they parse it as a virtual machine ID. The virtual machine also has to
+# expose an output, because the OS disk lock and network access updater read its managed disk id
+# back off the created machine.
+override_resource {
+  target = azapi_resource.this_linux_virtual_machine
+  values = {
+    id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/virtualMachines/vm-test"
+    output = {
+      identity = {
+        principalId = "11111111-1111-1111-1111-111111111111"
+        tenantId    = "22222222-2222-2222-2222-222222222222"
+      }
+      properties = {
+        vmId = "33333333-3333-3333-3333-333333333333"
+        storageProfile = {
+          osDisk = {
+            managedDisk = {
+              id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/disks/vm-test-osdisk"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
 variables {
   location            = "eastus"
   name                = "vm-locks"
@@ -97,7 +124,7 @@ run "virtual_machine_lock_carries_notes" {
     error_message = "A Linux virtual machine lock must be created when the lock variable is supplied."
   }
   assert {
-    condition     = azapi_resource.this_linux_virtualmachine_lock[0].parent_id == "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/virtualMachines/vm-locks"
+    condition     = azapi_resource.this_linux_virtualmachine_lock[0].parent_id == azapi_resource.this_linux_virtual_machine[0].id
     error_message = "The virtual machine lock must be parented to the virtual machine."
   }
   assert {

--- a/tests/unit/interface_role_assignments.tftest.hcl
+++ b/tests/unit/interface_role_assignments.tftest.hcl
@@ -60,6 +60,33 @@ override_resource {
     id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/disks/disk-test"
   }
 }
+# The blanket azapi_resource mock gives every azapi resource the same id, which the still-azurerm
+# resources reject when they parse it as a virtual machine ID. The virtual machine also has to
+# expose an output, because the OS disk lock and network access updater read its managed disk id
+# back off the created machine.
+override_resource {
+  target = azapi_resource.this_linux_virtual_machine
+  values = {
+    id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/virtualMachines/vm-test"
+    output = {
+      identity = {
+        principalId = "11111111-1111-1111-1111-111111111111"
+        tenantId    = "22222222-2222-2222-2222-222222222222"
+      }
+      properties = {
+        vmId = "33333333-3333-3333-3333-333333333333"
+        storageProfile = {
+          osDisk = {
+            managedDisk = {
+              id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/disks/vm-test-osdisk"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
 variables {
   location            = "eastus"
   name                = "vm-rbac"
@@ -117,7 +144,7 @@ run "virtual_machine_role_assignment_is_scoped_to_the_machine" {
   }
 
   assert {
-    condition     = azapi_resource.this_virtual_machine_role_assignments["vm_reader"].parent_id == "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/virtualMachines/vm-rbac"
+    condition     = azapi_resource.this_virtual_machine_role_assignments["vm_reader"].parent_id == azapi_resource.this_linux_virtual_machine[0].id
     error_message = "A virtual machine role assignment must be parented to the virtual machine."
   }
   assert {

--- a/tests/unit/linux_vm_body.tftest.hcl
+++ b/tests/unit/linux_vm_body.tftest.hcl
@@ -1,0 +1,347 @@
+mock_provider "azapi" {
+  mock_resource "azapi_resource" {
+    defaults = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/networkInterfaces/nic-test"
+    }
+  }
+}
+mock_provider "azurerm" {}
+mock_provider "modtm" {}
+mock_provider "random" {}
+mock_provider "tls" {}
+
+override_resource {
+  target = azapi_resource.this_linux_virtual_machine
+  values = {
+    id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/virtualMachines/vm-test"
+    output = {
+      identity = {
+        principalId = "11111111-1111-1111-1111-111111111111"
+        tenantId    = "22222222-2222-2222-2222-222222222222"
+      }
+      properties = {
+        vmId = "33333333-3333-3333-3333-333333333333"
+        storageProfile = {
+          osDisk = {
+            managedDisk = {
+              id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/disks/vm-test-osdisk"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+variables {
+  location            = "eastus"
+  name                = "vm-body"
+  resource_group_name = "rg-test"
+  zone                = "1"
+  os_type             = "Linux"
+  sku_size            = "Standard_D2s_v3"
+  account_credentials = {
+    admin_credentials = {
+      generate_admin_password_or_ssh_key = false
+      ssh_keys                           = ["ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQChdqi+GemIsVzHEtcwAuBai8F9qfDB0vvCukphTa4WGZFJ4BJCTGhzNU3FZmBlP8/uuF8MVKXwDFsM8dSZnWldbGTBK/US6qBHK4ewu/8Fd4AqT00yPeb4354wcvyluAKqLeXh29/ILTSO/WlW4tGD/Mzx9B/qicYHyEqrYY307yAiTHps3Yi02OzG1BAprhdDz3OCyzvjgHeM8ltKokrv1/+h49oTX96pIsSVNaH6RBIsSiTSD4DAnlpeqrSacwP6az1IDFfkDob6hn2I29lJitQWuIw/Vi2hiUysPqPhs8StpXfasVfjK8NwQA0eu3KBRAGSM6OnXk+NVxeise45rjRVBKtSLd37KRQWZrOcvorlG8nZRn8TDZc8ECQbF/FJQRApT0Vf0Yxf1sdEwpcNO9/o6vnhhEY4KbFbE53xQsx0+QXdQQ+Milg7F8P/lIW9/fFVBSG07kg1qtOpj4LaHxGfwFZwyCWSAvAJ13WIlomCO/HLY3aa07zO3l6jowofJzh3WVHCaGL/Gwg1KuNYS1Hi0Hu0KXwAKeS1YQnkdfaDD7Xvf2TeP3Jzis8iDWyXrZav1XVgtOcDsOkQ3lTkdhunRGyOeqCJrxBvCAiG+N3Lb4h09SJVOIN54lBZAUFRGWjbmawNPfQkTYt8asep/yrLsfokyrBlei6rdacHPQ== avm-unit-test"]
+    }
+  }
+  network_interfaces = {
+    nic1 = {
+      name = "nic-test"
+      ip_configurations = {
+        ipconfig1 = {
+          name                          = "ipconfig1"
+          private_ip_subnet_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-test/subnets/snet-test"
+        }
+      }
+    }
+  }
+  source_image_reference = {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-focal"
+    sku       = "20_04-lts-gen2"
+    version   = "latest"
+  }
+}
+
+run "core_attributes_are_mapped_to_arm_names" {
+  command = apply
+
+  assert {
+    condition     = local.linux_vm_body.properties.hardwareProfile.vmSize == "Standard_D2s_v3"
+    error_message = "sku_size must map to properties.hardwareProfile.vmSize."
+  }
+  assert {
+    condition     = local.linux_vm_body.properties.osProfile.computerName == "vm-body"
+    error_message = "The computer name must default to the virtual machine name."
+  }
+  assert {
+    condition     = local.linux_vm_body.properties.storageProfile.imageReference.publisher == "Canonical"
+    error_message = "source_image_reference must map to properties.storageProfile.imageReference."
+  }
+  assert {
+    condition     = local.linux_vm_body.properties.storageProfile.osDisk.createOption == "FromImage"
+    error_message = "A virtual machine built from an image must use the FromImage create option."
+  }
+  assert {
+    condition     = one(local.linux_vm_body.zones) == "1"
+    error_message = "zone must map to the ARM zones list."
+  }
+  assert {
+    condition     = azapi_resource.this_linux_virtual_machine[0].type == "Microsoft.Compute/virtualMachines@2024-11-01"
+    error_message = "The virtual machine must use the compute_virtual_machines resource type."
+  }
+}
+
+run "the_first_interface_is_marked_primary" {
+  command = apply
+
+  variables {
+    network_interfaces = {
+      nic1 = {
+        name       = "nic-one"
+        is_primary = true
+        ip_configurations = {
+          ipconfig1 = {
+            name                          = "ipconfig1"
+            private_ip_subnet_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-test/subnets/snet-test"
+          }
+        }
+      }
+      nic2 = {
+        name = "nic-two"
+        ip_configurations = {
+          ipconfig1 = {
+            name                          = "ipconfig1"
+            private_ip_subnet_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-test/subnets/snet-test"
+          }
+        }
+      }
+    }
+  }
+
+  assert {
+    condition     = local.linux_vm_body.properties.networkProfile.networkInterfaces[0].properties.primary == true
+    error_message = "ARM marks the first interface primary, so the ordered interface list must put the primary first."
+  }
+  assert {
+    condition     = local.linux_vm_body.properties.networkProfile.networkInterfaces[1].properties.primary == false
+    error_message = "Only one interface can be primary."
+  }
+}
+
+run "ssh_keys_are_public_and_stay_in_the_ordinary_body" {
+  command = apply
+
+  assert {
+    condition     = local.linux_vm_body.properties.osProfile.linuxConfiguration.disablePasswordAuthentication == true
+    error_message = "Supplying ssh keys must disable password authentication."
+  }
+  assert {
+    condition     = length(local.linux_vm_body.properties.osProfile.linuxConfiguration.ssh.publicKeys) == 1
+    error_message = "The supplied ssh key must be carried into linuxConfiguration.ssh.publicKeys."
+  }
+  assert {
+    condition     = local.linux_vm_body.properties.osProfile.linuxConfiguration.ssh.publicKeys[0].path == "/home/azureuser/.ssh/authorized_keys"
+    error_message = "ARM addresses an ssh key by the authorized_keys path of its user."
+  }
+  assert {
+    condition     = local.linux_vm_sensitive_body == null
+    error_message = "A machine with no password and no custom data must not populate sensitive_body, so consumers on Terraform 1.10 are unaffected."
+  }
+}
+
+# A password must never reach `body`, because `body` is not a sensitive attribute and would expose
+# it in plan output and in state.
+run "a_password_goes_to_sensitive_body_only" {
+  command = apply
+
+  variables {
+    account_credentials = {
+      admin_credentials = {
+        generate_admin_password_or_ssh_key = false
+        password                           = "P@ssw0rd1234!example"
+      }
+      password_authentication_disabled = false
+    }
+  }
+
+  assert {
+    condition     = !can(local.linux_vm_body.properties.osProfile.adminPassword)
+    error_message = "The admin password must never appear in the ordinary body."
+  }
+  assert {
+    condition     = local.linux_vm_sensitive_body.properties.osProfile.adminPassword == "P@ssw0rd1234!example"
+    error_message = "The admin password must be supplied through sensitive_body."
+  }
+  assert {
+    condition     = local.linux_vm_body.properties.osProfile.linuxConfiguration.disablePasswordAuthentication == false
+    error_message = "Password authentication must be enabled when a password is supplied."
+  }
+  assert {
+    condition     = local.linux_vm_secret_fingerprint != null
+    error_message = "A fingerprint must be produced so a password change still triggers replacement."
+  }
+}
+
+# merge is shallow, so a body built by merging two objects that each nest properties.osProfile
+# would silently drop the first. Both secrets must survive together.
+run "a_password_and_custom_data_both_survive" {
+  command = apply
+
+  variables {
+    custom_data = "IyEvYmluL2Jhc2gKZWNobyBoZWxsbwo="
+    account_credentials = {
+      admin_credentials = {
+        generate_admin_password_or_ssh_key = false
+        password                           = "P@ssw0rd1234!example"
+      }
+      password_authentication_disabled = false
+    }
+  }
+
+  assert {
+    condition     = local.linux_vm_sensitive_body.properties.osProfile.adminPassword == "P@ssw0rd1234!example"
+    error_message = "The admin password must survive alongside custom data."
+  }
+  assert {
+    condition     = local.linux_vm_sensitive_body.properties.osProfile.customData == "IyEvYmluL2Jhc2gKZWNobyBoZWxsbwo="
+    error_message = "Custom data must survive alongside the admin password."
+  }
+  assert {
+    condition     = !can(local.linux_vm_body.properties.osProfile.customData)
+    error_message = "Custom data must never appear in the ordinary body."
+  }
+}
+
+run "optional_profiles_are_absent_when_unconfigured" {
+  command = apply
+
+  assert {
+    condition     = !can(local.linux_vm_body.properties.diagnosticsProfile)
+    error_message = "diagnosticsProfile must be omitted when boot diagnostics are off."
+  }
+  assert {
+    condition     = !can(local.linux_vm_body.properties.additionalCapabilities)
+    error_message = "additionalCapabilities must be omitted when not configured."
+  }
+  assert {
+    condition     = !can(local.linux_vm_body.identity)
+    error_message = "identity must be omitted when no managed identity is requested."
+  }
+  assert {
+    condition     = !can(local.linux_vm_body.plan)
+    error_message = "plan must be omitted when not supplied."
+  }
+  assert {
+    condition     = !can(local.linux_vm_body.properties.applicationProfile)
+    error_message = "applicationProfile must be omitted when no gallery applications are supplied."
+  }
+}
+
+run "identity_and_boot_diagnostics_are_mapped" {
+  command = apply
+
+  variables {
+    boot_diagnostics = true
+    managed_identities = {
+      system_assigned = true
+    }
+  }
+
+  assert {
+    condition     = local.linux_vm_body.identity.type == "SystemAssigned"
+    error_message = "A system assigned identity must map to the ARM identity block."
+  }
+  assert {
+    condition     = local.linux_vm_body.properties.diagnosticsProfile.bootDiagnostics.enabled == true
+    error_message = "boot_diagnostics must map to diagnosticsProfile.bootDiagnostics.enabled."
+  }
+}
+
+run "trusted_launch_maps_to_the_security_profile" {
+  command = apply
+
+  variables {
+    secure_boot_enabled = true
+    vtpm_enabled        = true
+  }
+
+  assert {
+    condition     = local.linux_vm_body.properties.securityProfile.uefiSettings.secureBootEnabled == true
+    error_message = "secure_boot_enabled must map to securityProfile.uefiSettings.secureBootEnabled."
+  }
+  assert {
+    condition     = local.linux_vm_body.properties.securityProfile.uefiSettings.vTpmEnabled == true
+    error_message = "vtpm_enabled must map to securityProfile.uefiSettings.vTpmEnabled."
+  }
+  assert {
+    condition     = local.linux_vm_body.properties.securityProfile.securityType == "TrustedLaunch"
+    error_message = "ARM requires a security type alongside the UEFI settings."
+  }
+}
+
+# The body is a single dynamic attribute: if its shape depended on a value the caller computes,
+# the whole body would be unknown at plan time and every policy check on the virtual machine would
+# be blind. Only inputs decide the shape, never a computed value.
+run "the_body_shape_does_not_depend_on_a_computed_zone" {
+  command = apply
+
+  variables {
+    zone = null
+  }
+
+  assert {
+    condition     = length(local.linux_vm_body.zones) == 0
+    error_message = "A regional machine must send an empty zones list rather than changing the body's shape."
+  }
+  assert {
+    condition     = local.linux_vm_body.properties.hardwareProfile.vmSize == "Standard_D2s_v3"
+    error_message = "The rest of the body must stay readable when no zone is configured."
+  }
+}
+
+run "immutable_properties_force_replacement" {
+  command = apply
+
+  assert {
+    condition     = contains(azapi_resource.this_linux_virtual_machine[0].replace_triggers_refs, "properties.storageProfile.imageReference")
+    error_message = "source_image_reference is ForceNew under azurerm and must trigger replacement under AzAPI."
+  }
+  assert {
+    condition     = contains(azapi_resource.this_linux_virtual_machine[0].replace_triggers_refs, "properties.osProfile.adminUsername")
+    error_message = "admin_username is ForceNew under azurerm and must trigger replacement under AzAPI."
+  }
+  assert {
+    condition     = contains(azapi_resource.this_linux_virtual_machine[0].replace_triggers_refs, "zones")
+    error_message = "zone is ForceNew under azurerm and must trigger replacement under AzAPI."
+  }
+  assert {
+    condition     = !contains(azapi_resource.this_linux_virtual_machine[0].replace_triggers_refs, "properties.hardwareProfile.vmSize")
+    error_message = "Resizing a virtual machine is an in-place operation and must not force replacement."
+  }
+}
+
+run "the_virtual_machine_azurerm_output_keeps_its_shape" {
+  command = apply
+
+  variables {
+    managed_identities = {
+      system_assigned = true
+    }
+  }
+
+  assert {
+    condition     = local.linux_virtual_machine_output_map.id == azapi_resource.this_linux_virtual_machine[0].id
+    error_message = "The compatibility output must expose the virtual machine resource id."
+  }
+  assert {
+    condition     = local.linux_virtual_machine_output_map.virtual_machine_id == "33333333-3333-3333-3333-333333333333"
+    error_message = "virtual_machine_id must come from the ARM vmId, which azurerm exposed under that name."
+  }
+  assert {
+    condition     = local.linux_virtual_machine_output_map.identity[0].principal_id == "11111111-1111-1111-1111-111111111111"
+    error_message = "azurerm exposed identity as a single element list, so the shape must be preserved."
+  }
+}

--- a/tests/unit/linux_vm_body.tftest.hcl
+++ b/tests/unit/linux_vm_body.tftest.hcl
@@ -85,6 +85,10 @@ run "core_attributes_are_mapped_to_arm_names" {
     error_message = "A virtual machine built from an image must use the FromImage create option."
   }
   assert {
+    condition     = local.linux_vm_body.properties.storageProfile.osDisk.deleteOption == "Delete"
+    error_message = "azurerm deleted the OS disk on destroy through delete_os_disk_on_deletion, so ARM must be asked to do the same or the disk is orphaned and keeps billing."
+  }
+  assert {
     condition     = one(local.linux_vm_body.zones) == "1"
     error_message = "zone must map to the ARM zones list."
   }

--- a/tests/unit/linux_vm_body.tftest.hcl
+++ b/tests/unit/linux_vm_body.tftest.hcl
@@ -343,6 +343,35 @@ run "the_body_shape_does_not_depend_on_a_computed_zone" {
   }
 }
 
+# A resource id the caller computes must not decide whether a key exists. A conditional keyed on an
+# unknown makes the whole merge unknown, and that hid every policy check on the machine behind an
+# unknown `properties` object until it was caught by the resiliency rules.
+run "resource_id_inputs_do_not_decide_the_shape_of_the_body" {
+  command = apply
+
+  assert {
+    condition     = local.linux_vm_body.properties.virtualMachineScaleSet == null
+    error_message = "virtual_machine_scale_set_resource_id is routinely computed, so the key must always exist and carry null when unset."
+  }
+  assert {
+    condition     = local.linux_vm_body.properties.proximityPlacementGroup == null
+    error_message = "proximity_placement_group_resource_id is routinely computed, so the key must always exist and carry null when unset."
+  }
+  assert {
+    condition     = local.linux_vm_body.properties.storageProfile.osDisk.managedDisk.diskEncryptionSet == null
+    error_message = "os_disk.disk_encryption_set_id is routinely computed, so the key must always exist and carry null when unset."
+  }
+  assert {
+    condition     = local.linux_vm_body.properties.storageProfile.osDisk.managedDisk.storageAccountType == "Premium_LRS"
+    error_message = "The storage account type must stay readable alongside the computed members, because the resiliency rules read it."
+  }
+  # Policy requires this one to be absent rather than null, so it is the deliberate exception.
+  assert {
+    condition     = !can(local.linux_vm_body.properties.availabilitySet)
+    error_message = "availabilitySet must be omitted entirely when unset, because the resiliency rule treats a null as defined."
+  }
+}
+
 run "immutable_properties_force_replacement" {
   command = apply
 

--- a/tests/unit/linux_vm_body.tftest.hcl
+++ b/tests/unit/linux_vm_body.tftest.hcl
@@ -376,10 +376,6 @@ run "immutable_properties_force_replacement" {
   command = apply
 
   assert {
-    condition     = contains(azapi_resource.this_linux_virtual_machine[0].replace_triggers_refs, "properties.storageProfile.imageReference")
-    error_message = "source_image_reference is ForceNew under azurerm and must trigger replacement under AzAPI."
-  }
-  assert {
     condition     = contains(azapi_resource.this_linux_virtual_machine[0].replace_triggers_refs, "properties.osProfile.adminUsername")
     error_message = "admin_username is ForceNew under azurerm and must trigger replacement under AzAPI."
   }
@@ -390,6 +386,40 @@ run "immutable_properties_force_replacement" {
   assert {
     condition     = !contains(azapi_resource.this_linux_virtual_machine[0].replace_triggers_refs, "properties.hardwareProfile.vmSize")
     error_message = "Resizing a virtual machine is an in-place operation and must not force replacement."
+  }
+}
+
+# A body path may only be watched when the module always sends a real value for it. A path the
+# module can omit, or send as null to keep the shape of the body readable, differs from the body a
+# moved block adopts from Azure, and watching it replaces an adopted machine.
+run "omittable_paths_are_watched_through_their_inputs" {
+  command = apply
+
+  variables {
+    source_image_reference = {
+      publisher = "Canonical"
+      offer     = "0001-com-ubuntu-server-focal"
+      sku       = "20_04-lts-gen2"
+      version   = "latest"
+    }
+  }
+
+  assert {
+    condition     = !contains(azapi_resource.this_linux_virtual_machine[0].replace_triggers_refs, "properties.storageProfile.imageReference")
+    error_message = "The image reference is sent as null in attach mode, so watching the body path would replace an adopted machine."
+  }
+  assert {
+    condition     = !contains(azapi_resource.this_linux_virtual_machine[0].replace_triggers_refs, "properties.osProfile.linuxConfiguration.ssh")
+    error_message = "The ssh block is omitted when no keys are supplied, so watching the body path would replace an adopted machine."
+  }
+  assert {
+    condition     = !contains(azapi_resource.this_linux_virtual_machine[0].replace_triggers_refs, "properties.storageProfile.osDisk.managedDisk.securityProfile")
+    error_message = "The disk security profile is sent as null when unset, so watching the body path would replace an adopted machine."
+  }
+  # The image is still ForceNew, it is simply watched through the input instead.
+  assert {
+    condition     = contains(azapi_resource.this_linux_virtual_machine[0].replace_triggers_external_values, jsonencode(local.source_image_reference))
+    error_message = "source_image_reference is ForceNew under azurerm and must still replace the machine when it changes."
   }
 }
 

--- a/tests/unit/linux_vm_body.tftest.hcl
+++ b/tests/unit/linux_vm_body.tftest.hcl
@@ -215,6 +215,43 @@ run "a_password_and_custom_data_both_survive" {
   }
 }
 
+run "guest_patching_maps_to_the_patch_settings" {
+  command = apply
+
+  variables {
+    patch_mode            = "AutomaticByPlatform"
+    patch_assessment_mode = "AutomaticByPlatform"
+    reboot_setting        = "IfRequired"
+  }
+
+  assert {
+    condition     = local.linux_vm_body.properties.osProfile.linuxConfiguration.patchSettings.patchMode == "AutomaticByPlatform"
+    error_message = "patch_mode must map to linuxConfiguration.patchSettings.patchMode."
+  }
+  assert {
+    condition     = local.linux_vm_body.properties.osProfile.linuxConfiguration.patchSettings.assessmentMode == "AutomaticByPlatform"
+    error_message = "patch_assessment_mode must map to linuxConfiguration.patchSettings.assessmentMode."
+  }
+  assert {
+    condition     = local.linux_vm_body.properties.osProfile.linuxConfiguration.patchSettings.automaticByPlatformSettings.rebootSetting == "IfRequired"
+    error_message = "reboot_setting must map to the automatic by platform settings."
+  }
+}
+
+run "the_automatic_by_platform_settings_are_omitted_for_other_patch_modes" {
+  command = apply
+
+  variables {
+    patch_mode     = "ImageDefault"
+    reboot_setting = "IfRequired"
+  }
+
+  assert {
+    condition     = !can(local.linux_vm_body.properties.osProfile.linuxConfiguration.patchSettings.automaticByPlatformSettings)
+    error_message = "ARM rejects the automatic by platform settings unless the patch mode is AutomaticByPlatform."
+  }
+}
+
 run "optional_profiles_are_absent_when_unconfigured" {
   command = apply
 

--- a/tests/unit/linux_vm_body.tftest.hcl
+++ b/tests/unit/linux_vm_body.tftest.hcl
@@ -360,6 +360,39 @@ run "immutable_properties_force_replacement" {
   }
 }
 
+# Azure fills in the OS disk name and its resource id, so both are present in the body a moved
+# block adopts but absent from the body this module sends. Watching the body paths would read that
+# as an immutable change and replace an adopted machine.
+run "server_assigned_os_disk_values_do_not_force_replacement" {
+  command = apply
+
+  assert {
+    condition     = !contains(azapi_resource.this_linux_virtual_machine[0].replace_triggers_refs, "properties.storageProfile.osDisk.name")
+    error_message = "Azure names the OS disk when the input is null, so the body path must not be a replacement trigger."
+  }
+  assert {
+    condition     = !contains(azapi_resource.this_linux_virtual_machine[0].replace_triggers_refs, "properties.storageProfile.osDisk.managedDisk.id")
+    error_message = "Azure assigns the OS disk id for an image build, so the body path must not be a replacement trigger."
+  }
+}
+
+run "the_os_disk_inputs_behind_them_still_force_replacement" {
+  command = apply
+
+  variables {
+    os_disk = {
+      caching              = "ReadWrite"
+      storage_account_type = "Premium_LRS"
+      name                 = "osdisk-explicit"
+    }
+  }
+
+  assert {
+    condition     = contains(azapi_resource.this_linux_virtual_machine[0].replace_triggers_external_values, "osdisk-explicit")
+    error_message = "os_disk.name is ForceNew under azurerm, so changing it must still replace the machine."
+  }
+}
+
 run "the_virtual_machine_azurerm_output_keeps_its_shape" {
   command = apply
 

--- a/tests/unit/network_interface_body.tftest.hcl
+++ b/tests/unit/network_interface_body.tftest.hcl
@@ -13,6 +13,33 @@ mock_provider "modtm" {}
 mock_provider "random" {}
 mock_provider "tls" {}
 
+# The blanket azapi_resource mock gives every azapi resource the same id, which the still-azurerm
+# resources reject when they parse it as a virtual machine ID. The virtual machine also has to
+# expose an output, because the OS disk lock and network access updater read its managed disk id
+# back off the created machine.
+override_resource {
+  target = azapi_resource.this_linux_virtual_machine
+  values = {
+    id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/virtualMachines/vm-test"
+    output = {
+      identity = {
+        principalId = "11111111-1111-1111-1111-111111111111"
+        tenantId    = "22222222-2222-2222-2222-222222222222"
+      }
+      properties = {
+        vmId = "33333333-3333-3333-3333-333333333333"
+        storageProfile = {
+          osDisk = {
+            managedDisk = {
+              id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/disks/vm-test-osdisk"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
 variables {
   location            = "eastus"
   name                = "vm-nic-body"

--- a/tests/unit/network_parent_id.tftest.hcl
+++ b/tests/unit/network_parent_id.tftest.hcl
@@ -13,6 +13,33 @@ mock_provider "modtm" {}
 mock_provider "random" {}
 mock_provider "tls" {}
 
+# The blanket azapi_resource mock gives every azapi resource the same id, which the still-azurerm
+# resources reject when they parse it as a virtual machine ID. The virtual machine also has to
+# expose an output, because the OS disk lock and network access updater read its managed disk id
+# back off the created machine.
+override_resource {
+  target = azapi_resource.this_linux_virtual_machine
+  values = {
+    id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/virtualMachines/vm-test"
+    output = {
+      identity = {
+        principalId = "11111111-1111-1111-1111-111111111111"
+        tenantId    = "22222222-2222-2222-2222-222222222222"
+      }
+      properties = {
+        vmId = "33333333-3333-3333-3333-333333333333"
+        storageProfile = {
+          osDisk = {
+            managedDisk = {
+              id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/disks/vm-test-osdisk"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
 variables {
   location            = "eastus"
   name                = "vm-parent-id"

--- a/tests/unit/os_disk_attach_mode.tftest.hcl
+++ b/tests/unit/os_disk_attach_mode.tftest.hcl
@@ -131,8 +131,11 @@ run "linux_attach_mode_omits_os_profile_attributes" {
     condition     = local.linux_vm_body.properties.storageProfile.osDisk.deleteOption == "Detach"
     error_message = "A disk the caller attached belongs to them and must survive the machine."
   }
+  # The key is always present so that a computed image id cannot collapse the shape of the body
+  # and hide it from policy checks, so absence is expressed as a null value rather than a missing
+  # key.
   assert {
-    condition     = !can(local.linux_vm_body.properties.storageProfile.imageReference)
+    condition     = local.linux_vm_body.properties.storageProfile.imageReference == null
     error_message = "An imported OS disk must not also carry an image reference."
   }
 }

--- a/tests/unit/os_disk_attach_mode.tftest.hcl
+++ b/tests/unit/os_disk_attach_mode.tftest.hcl
@@ -51,6 +51,33 @@ mock_provider "random" {
 }
 mock_provider "tls" {}
 
+# The blanket azapi_resource mock gives every azapi resource the same id, which the still-azurerm
+# resources reject when they parse it as a virtual machine ID. The virtual machine also has to
+# expose an output, because the OS disk lock and network access updater read its managed disk id
+# back off the created machine.
+override_resource {
+  target = azapi_resource.this_linux_virtual_machine
+  values = {
+    id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/virtualMachines/vm-test"
+    output = {
+      identity = {
+        principalId = "11111111-1111-1111-1111-111111111111"
+        tenantId    = "22222222-2222-2222-2222-222222222222"
+      }
+      properties = {
+        vmId = "33333333-3333-3333-3333-333333333333"
+        storageProfile = {
+          osDisk = {
+            managedDisk = {
+              id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/disks/vm-test-osdisk"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
 variables {
   location            = "eastus"
   name                = "vm-attach-mode"
@@ -93,12 +120,16 @@ run "linux_attach_mode_omits_os_profile_attributes" {
   }
 
   assert {
-    condition     = azurerm_linux_virtual_machine.this[0].allow_extension_operations == true
-    error_message = "allow_extension_operations must not be sent in attach mode - updating it rewrites osProfile, which Azure rejects with 409 PropertyChangeNotAllowed on an imported VM."
+    condition     = !can(local.linux_vm_body.properties.osProfile)
+    error_message = "osProfile must not be sent in attach mode - updating it rewrites the profile, which Azure rejects with 409 PropertyChangeNotAllowed on an imported VM."
   }
   assert {
-    condition     = azurerm_linux_virtual_machine.this[0].disable_password_authentication == true
-    error_message = "disable_password_authentication must not be sent in attach mode - it is part of osProfile and is ForceNew, so an imported VM would be planned for replacement."
+    condition     = local.linux_vm_body.properties.storageProfile.osDisk.createOption == "Attach"
+    error_message = "An imported OS disk must be attached rather than created from an image."
+  }
+  assert {
+    condition     = !can(local.linux_vm_body.properties.storageProfile.imageReference)
+    error_message = "An imported OS disk must not also carry an image reference."
   }
 }
 
@@ -116,11 +147,11 @@ run "linux_without_attach_mode_honours_os_profile_attributes" {
   }
 
   assert {
-    condition     = azurerm_linux_virtual_machine.this[0].allow_extension_operations == false
+    condition     = local.linux_vm_body.properties.osProfile.allowExtensionOperations == false
     error_message = "allow_extension_operations must still be taken from the input variable when attach mode is not in use."
   }
   assert {
-    condition     = azurerm_linux_virtual_machine.this[0].disable_password_authentication == false
+    condition     = local.linux_vm_body.properties.osProfile.linuxConfiguration.disablePasswordAuthentication == false
     error_message = "disable_password_authentication must still be taken from the credential inputs when attach mode is not in use."
   }
 }

--- a/tests/unit/os_disk_attach_mode.tftest.hcl
+++ b/tests/unit/os_disk_attach_mode.tftest.hcl
@@ -128,6 +128,10 @@ run "linux_attach_mode_omits_os_profile_attributes" {
     error_message = "An imported OS disk must be attached rather than created from an image."
   }
   assert {
+    condition     = local.linux_vm_body.properties.storageProfile.osDisk.deleteOption == "Detach"
+    error_message = "A disk the caller attached belongs to them and must survive the machine."
+  }
+  assert {
     condition     = !can(local.linux_vm_body.properties.storageProfile.imageReference)
     error_message = "An imported OS disk must not also carry an image reference."
   }

--- a/tests/unit/os_disk_lock.tftest.hcl
+++ b/tests/unit/os_disk_lock.tftest.hcl
@@ -30,6 +30,33 @@ mock_provider "modtm" {}
 mock_provider "random" {}
 mock_provider "tls" {}
 
+# The blanket azapi_resource mock gives every azapi resource the same id, which the still-azurerm
+# resources reject when they parse it as a virtual machine ID. The virtual machine also has to
+# expose an output, because the OS disk lock and network access updater read its managed disk id
+# back off the created machine.
+override_resource {
+  target = azapi_resource.this_linux_virtual_machine
+  values = {
+    id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/virtualMachines/vm-test"
+    output = {
+      identity = {
+        principalId = "11111111-1111-1111-1111-111111111111"
+        tenantId    = "22222222-2222-2222-2222-222222222222"
+      }
+      properties = {
+        vmId = "33333333-3333-3333-3333-333333333333"
+        storageProfile = {
+          osDisk = {
+            managedDisk = {
+              id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/disks/vm-test-osdisk"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
 variables {
   location            = "eastus"
   name                = "vm-os-disk-lock"
@@ -110,7 +137,7 @@ run "os_disk_lock_cannot_delete" {
     error_message = "The OS disk lock name must be generated from the virtual machine name when lock_name is not supplied."
   }
   assert {
-    condition     = azapi_resource.this_os_disk_lock[0].parent_id == "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/disks/vm-os-disk-lock-osdisk"
+    condition     = azapi_resource.this_os_disk_lock[0].parent_id == azapi_resource.this_linux_virtual_machine[0].output.properties.storageProfile.osDisk.managedDisk.id && azapi_resource.this_os_disk_lock[0].parent_id != azapi_resource.this_linux_virtual_machine[0].id
     error_message = "The OS disk lock must be scoped to the OS disk resource id, not the virtual machine."
   }
 }

--- a/tests/unit/os_disk_network_access.tftest.hcl
+++ b/tests/unit/os_disk_network_access.tftest.hcl
@@ -27,6 +27,33 @@ mock_provider "modtm" {}
 mock_provider "random" {}
 mock_provider "tls" {}
 
+# The blanket azapi_resource mock gives every azapi resource the same id, which the still-azurerm
+# resources reject when they parse it as a virtual machine ID. The virtual machine also has to
+# expose an output, because the OS disk lock and network access updater read its managed disk id
+# back off the created machine.
+override_resource {
+  target = azapi_resource.this_linux_virtual_machine
+  values = {
+    id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/virtualMachines/vm-test"
+    output = {
+      identity = {
+        principalId = "11111111-1111-1111-1111-111111111111"
+        tenantId    = "22222222-2222-2222-2222-222222222222"
+      }
+      properties = {
+        vmId = "33333333-3333-3333-3333-333333333333"
+        storageProfile = {
+          osDisk = {
+            managedDisk = {
+              id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/disks/vm-test-osdisk"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
 variables {
   location            = "eastus"
   name                = "vm-os-disk-net-access"

--- a/tests/unit/public_ip_body.tftest.hcl
+++ b/tests/unit/public_ip_body.tftest.hcl
@@ -13,6 +13,33 @@ mock_provider "modtm" {}
 mock_provider "random" {}
 mock_provider "tls" {}
 
+# The blanket azapi_resource mock gives every azapi resource the same id, which the still-azurerm
+# resources reject when they parse it as a virtual machine ID. The virtual machine also has to
+# expose an output, because the OS disk lock and network access updater read its managed disk id
+# back off the created machine.
+override_resource {
+  target = azapi_resource.this_linux_virtual_machine
+  values = {
+    id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/virtualMachines/vm-test"
+    output = {
+      identity = {
+        principalId = "11111111-1111-1111-1111-111111111111"
+        tenantId    = "22222222-2222-2222-2222-222222222222"
+      }
+      properties = {
+        vmId = "33333333-3333-3333-3333-333333333333"
+        storageProfile = {
+          osDisk = {
+            managedDisk = {
+              id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Compute/disks/vm-test-osdisk"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
 variables {
   location            = "eastus"
   name                = "vm-public-ip"

--- a/variables.tf
+++ b/variables.tf
@@ -732,6 +732,7 @@ variable "ignore_body_changes" {
     network_network_interfaces            = optional(list(string), [])
     network_public_ip_addresses           = optional(list(string), [])
     compute_disks                         = optional(list(string), [])
+    compute_virtual_machines              = optional(list(string), [])
 
     recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems = optional(object({
       recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems = optional(list(string), [])
@@ -754,6 +755,7 @@ apply.
 - `network_network_interfaces` - Ignored body paths for the network interfaces.
 - `network_public_ip_addresses` - Ignored body paths for the public IP addresses.
 - `compute_disks` - Ignored body paths for the data disks.
+- `compute_virtual_machines` - Ignored body paths for the virtual machine.
 - `recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems` - Paths passed to the backup submodule.
 - `recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems.recoveryservices_vaults_backupfabrics_protectioncontainers_protecteditems` - Ignored body paths for the backup protected item.
 DESCRIPTION
@@ -1375,6 +1377,7 @@ variable "resource_types" {
   type = object({
     maintenance_configuration_assignments = optional(string, "Microsoft.Maintenance/configurationAssignments@2023-04-01")
     compute_disks                         = optional(string, "Microsoft.Compute/disks@2024-03-02")
+    compute_virtual_machines              = optional(string, "Microsoft.Compute/virtualMachines@2024-11-01")
     authorization_locks                   = optional(string, "Microsoft.Authorization/locks@2020-05-01")
     authorization_role_assignments        = optional(string, "Microsoft.Authorization/roleAssignments@2022-04-01")
     insights_diagnostic_settings          = optional(string, "Microsoft.Insights/diagnosticSettings@2021-05-01-preview")
@@ -1393,6 +1396,7 @@ sovereign cloud with older API versions, or when opting into a newer preview API
 
 - `maintenance_configuration_assignments` - Maintenance configuration assignments applied to the virtual machine.
 - `compute_disks` - The managed disk type used when updating the OS disk network access settings.
+- `compute_virtual_machines` - The virtual machine.
 - `authorization_locks` - Management locks applied to the virtual machine and its child resources.
 - `authorization_role_assignments` - Role assignments applied to the virtual machine and its child resources.
 - `insights_diagnostic_settings` - Diagnostic settings applied to the virtual machine and its OS disk.


### PR DESCRIPTION
## Description

Step 4 of the azurerm to azapi migration, following #387, #392 and #396. Converts the **Linux** virtual machine to `azapi_resource`, keeping existing state through a `moved` block.

Two things are deliberately left out to keep this reviewable:

* The **Windows** virtual machine, which follows in its own PR and reuses the interface-derived IP logic added here.
* The **data disk attachments**. They only need a virtual machine ID, and AzAPI diffs only the fields present in `body`, so a body that omits `dataDisks` does not fight the existing attachment resources. Folding them in is a separate step.

Around 45 attributes and 11 blocks map into the ARM body, checked against the schema for `Microsoft.Compute/virtualMachines@2024-11-01`. Two mappings are worth calling out:

| Case | Behaviour |
|---|---|
| Attach mode | `osProfile` is omitted entirely, because Azure rejects a profile rewrite on an imported machine |
| Trusted launch | `secure_boot_enabled` and `vtpm_enabled` collapse into `securityProfile.uefiSettings`, alongside the `securityType` ARM requires whenever those settings are present |

## Trade-offs

**Secrets do not go into `body`.** `body` is not a sensitive attribute, so an admin password placed there would show up in plan output. `sensitive_body` keeps it out of both plan and state.

Worth being precise about the baseline: the azurerm provider marked `admin_password` sensitive, which hides it from output but still writes it to state in plaintext. So this is an improvement rather than a regression.

| | in state | in plan output |
|---|---|---|
| azurerm today | plaintext | hidden |
| AzAPI `body` | plaintext | visible |
| AzAPI `sensitive_body` | absent | hidden |

`sensitive_body` is write-only and needs Terraform 1.11, while the module floor is `>= 1.10`. Per TFNFR25 the floor is not raised. The attribute is only populated when a password or `custom_data` is actually supplied, so consumers using SSH keys are unaffected. Public SSH keys are not secret and stay in the ordinary body.

Because a write-only attribute is invisible to the provider, a change to it cannot be detected normally. Both values are ForceNew under azurerm and ARM cannot change either in place, so the correct equivalent is a replacement, driven by a hash of the secrets rather than the secrets themselves.

**Four outputs had to be rebuilt rather than mapped.** `private_ip_address`, `private_ip_addresses`, `public_ip_address` and `public_ip_addresses` are computed by the azurerm provider from the attached interfaces. ARM returns none of them on the virtual machine. They are now derived from the interface and public IP resources so `virtual_machine_azurerm` keeps working unchanged. `identity` is rewrapped as a single element list to match the shape consumers already index into.

**Thirty eight attributes are ForceNew under azurerm.** Those that live in the body are named in `replace_triggers_refs`, so an immutable edit plans a replacement instead of failing at apply.

## Test results

| Check | Result |
|---|---|
| `avm lint` | pass |
| `avm pre-commit` | pass |
| `avm test unit` | 85 runs, 85 passed, 0 failed (was 74) |

11 new unit tests cover the body mapping, the interface ordering, the SSH and password paths, the security profile, `replace_triggers_refs`, plan-time body knowability, and the output shim.

### Verified against Azure

Unit tests plan against mocks and e2e only creates on empty ground, so neither exercises a `moved` block. This was checked with a running Linux machine that had a system assigned identity, a data disk and boot diagnostics.

The **baseline noise floor was captured first**, by planning the un-migrated configuration, so environmental drift could be subtracted rather than argued about:

| Check | Result |
|---|---|
| Noise floor, before migrating | `0 to add, 3 to change, 0 to destroy` |
| Migration plan | `0 to add, 3 to change, 0 to destroy`, the same three, no replacements |
| Terraform reported | `(moved from module.testvm.azurerm_linux_virtual_machine.this[0])` |
| Apply | `0 added, 3 changed, 0 destroyed` |
| Second plan | Matches the noise floor exactly, with `body` absent from the virtual machine diff |
| Machine afterwards | Running, with identity, data disk, interface and boot diagnostics intact |
| Compatibility outputs | `private_ip_address`, `virtual_machine_id` and the identity principal all resolve |

The three changes in both plans are the resource group, the subnet and `azsecpack` tags that the test subscription applies on its own. They appear identically on the un-migrated baseline.

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks
