### PR TITLE
fix: stop setting a shutdown webhook the service discards

### DIFF
--- a/README.md
+++ b/README.md
@@ -1895,7 +1895,7 @@ Description: This map of objects describes an auto-shutdown schedule for the vir
     - `enabled` = (Required) Whether to enable pre-shutdown notifications.  Possible values are true or false.
     - `email` = (Optional) = Email address or multiple email addresses separated by a semi-colon where the notification emails will be sent.
     - `time_in_minutes` = (Optional) TIme in minutes between 15 and 120 before a shutdown event at which a notification will be sent.  Defaults to "30".
-    - `webhook_url` = (Optional) The webhook URL to which notifications will be sent.
+    - `webhook_url` = (Optional) The webhook URL to which notifications will be sent. Azure currently accepts this value and then discards it, so it is absent from every read and each plan will report it as a pending change. Leave it unset until the service honours it again.
   - `tags` = (Optional) - Tags to apply to the shutdown schedules resource.
   - `timezone` = (Required) - The time zone ID (e.g. Pacific Standard time).
 
@@ -1910,7 +1910,6 @@ Example Input:
         enabled         = true
         email           = "example@example.com;example2@example.com"
         time_in_minutes = "15"
-        webhook_url     = "https://example-webhook-url.example.com"
       }
     }
   }

--- a/examples/windows_w_additional_disks_public_ip/README.md
+++ b/examples/windows_w_additional_disks_public_ip/README.md
@@ -263,7 +263,6 @@ module "testvm" {
         enabled         = true
         email           = "example@example.com;example2@example.com"
         time_in_minutes = "15"
-        webhook_url     = "https://example-webhook-url.example.com"
       }
     }
   }

--- a/examples/windows_w_additional_disks_public_ip/main.tf
+++ b/examples/windows_w_additional_disks_public_ip/main.tf
@@ -243,7 +243,6 @@ module "testvm" {
         enabled         = true
         email           = "example@example.com;example2@example.com"
         time_in_minutes = "15"
-        webhook_url     = "https://example-webhook-url.example.com"
       }
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -1682,7 +1682,7 @@ This map of objects describes an auto-shutdown schedule for the virtual machine.
     - `enabled` = (Required) Whether to enable pre-shutdown notifications.  Possible values are true or false.
     - `email` = (Optional) = Email address or multiple email addresses separated by a semi-colon where the notification emails will be sent.
     - `time_in_minutes` = (Optional) TIme in minutes between 15 and 120 before a shutdown event at which a notification will be sent.  Defaults to "30".
-    - `webhook_url` = (Optional) The webhook URL to which notifications will be sent.
+    - `webhook_url` = (Optional) The webhook URL to which notifications will be sent. Azure currently accepts this value and then discards it, so it is absent from every read and each plan will report it as a pending change. Leave it unset until the service honours it again.
   - `tags` = (Optional) - Tags to apply to the shutdown schedules resource.
   - `timezone` = (Required) - The time zone ID (e.g. Pacific Standard time).
 
@@ -1697,7 +1697,6 @@ Example Input:
         enabled         = true
         email           = "example@example.com;example2@example.com"
         time_in_minutes = "15"
-        webhook_url     = "https://example-webhook-url.example.com"
       }
     }
   }


### PR DESCRIPTION
The `windows_w_additional_disks_public_ip` example sets a shutdown notification webhook. Azure accepts that value on write and then discards it, so the example can never reach a clean second plan and the end-to-end idempotency check fails on every pull request against this repository.

### Evidence

Reproduced with Terraform out of the picture, by sending the request straight to ARM. The `PUT` carried the property exactly as the specification documents it:

```json
"notificationSettings": {
  "status": "Enabled", "timeInMinutes": 15,
  "emailRecipient": "a@example.com",
  "webhookUrl": "https://example-webhook-url.example.com"
}
```

The response reported `"provisioningState": "Succeeded"` with no validation error, and echoed back:

```json
"notificationSettings": {
  "emailRecipient": "a@example.com",
  "status": "Enabled",
  "timeInMinutes": 15
}
```

A follow-up `GET` agrees, on both `2018-09-15` and `2016-05-15`. The casings `webHookUrl`, `WebhookUrl` and `webhookURL` were also tried and all are dropped, so this is not a casing mismatch.

The property is still documented: `models.tsp` in `azure-rest-api-specs` declares `webhookUrl?: string`, and the `Schedules_Get` example response includes it. The service is out of spec rather than the provider being wrong.

### Why it started

The example has carried this value since April 2025 and passed CI every time until 26 August. The provider build (v4.81.0), the example and the module code paths are all unchanged across that boundary, so the change is service side.

### Change

The webhook is removed from the example. The `shutdown_schedules` input keeps the property for callers who want it once the service honours it again, and its description now records the behaviour.

No module logic changes.