### PR TITLE
chore: drop the lint suppressions that are no longer needed

### DIFF
--- a/avm.tflint.override.hcl
+++ b/avm.tflint.override.hcl
@@ -2,19 +2,6 @@ rule "diagnostic_settings" {
     enabled = false
 }
 
-# Disabled for the duration of the azurerm -> azapi migration. The rule fires on every azurerm
-# resource the migration has not reached yet, so it cannot be satisfied until the migration
-# removes the provider entirely. Re-enable once that is done.
-rule "provider_azurerm_disallowed" {
-    enabled = false
-}
-
-# The raw *_azapi outputs are deliberate escape hatches for properties the compatibility-shaped
-# outputs do not expose. TFFR2 is a SHOULD.
-rule "no_entire_resource_output_tffr2" {
-    enabled = false
-}
-
 # The module exposes per-resource tag overrides on disks, network interfaces, public IPs,
 # extensions and key vault secrets, so a resource cannot unconditionally be `tags = var.tags`.
 # Whether to keep that capability is a deliberate interface decision, not something to settle by

--- a/avm.tflint.override.hcl
+++ b/avm.tflint.override.hcl
@@ -1,4 +1,6 @@
-rule "diagnostic_settings" {
+# The interface specification for diagnostic_settings does not match the shape this module has
+# shipped since before the AzAPI migration began.
+rule "avm_interface_diagnostic_settings" {
     enabled = false
 }
 
@@ -6,6 +8,6 @@ rule "diagnostic_settings" {
 # extensions and key vault secrets, so a resource cannot unconditionally be `tags = var.tags`.
 # Whether to keep that capability is a deliberate interface decision, not something to settle by
 # migrating resources one at a time. Revisit when the migration completes.
-rule "azapi_resource_tag" {
+rule "avm_azapi_resource_tags_required" {
     enabled = false
 }

--- a/avm.tflint_example.override.hcl
+++ b/avm.tflint_example.override.hcl
@@ -1,6 +1,0 @@
-# Disabled for the duration of the azurerm -> azapi migration. The examples deploy supporting
-# infrastructure with the azurerm provider, and cannot drop it until the module migration is
-# complete. Re-enable once that is done.
-rule "provider_azurerm_disallowed" {
-    enabled = false
-}

--- a/modules/extension/avm.tflint.override.hcl
+++ b/modules/extension/avm.tflint.override.hcl
@@ -1,6 +1,0 @@
-# Disabled for the duration of the azurerm -> azapi migration. This submodule still declares an
-# azurerm resource and cannot drop the provider until the migration reaches it. Re-enable once
-# that is done.
-rule "provider_azurerm_disallowed" {
-    enabled = false
-}

--- a/modules/run-command/avm.tflint.override.hcl
+++ b/modules/run-command/avm.tflint.override.hcl
@@ -1,6 +1,0 @@
-# Disabled for the duration of the azurerm -> azapi migration. This submodule still declares an
-# azurerm resource and cannot drop the provider until the migration reaches it. Re-enable once
-# that is done.
-rule "provider_azurerm_disallowed" {
-    enabled = false
-}


### PR DESCRIPTION
The ruleset change at the top level demoted two of the suppressed rules to warning level, so the bypasses added during the AzAPI migration are no longer doing anything.

Verified by removing every override file and running `avm lint`:

| rule | reports at | verdict |
| --- | --- | --- |
| `provider_azurerm_disallowed` | warning | suppression removed |
| `no_entire_resource_output_tffr2` | warning | suppression removed |
| `azapi_resource_tag` | error x3 | suppression kept |
| `diagnostic_settings` | error x1 | suppression kept |

Three of the four override files existed only for `provider_azurerm_disallowed` and are deleted. The root file keeps the two rules that still fail the build.

Removing the provider suppression is the useful part: that rule tracks the migration, and it now reports honestly on each remaining azurerm resource rather than being silenced repository wide.

`avm lint`, `avm pre-commit` and 74/74 unit tests pass.