### PR TITLE
fix: stop lint failing on the azapi declaration in the submodules

### DIFF
--- a/modules/extension/terraform.tf
+++ b/modules/extension/terraform.tf
@@ -2,6 +2,11 @@ terraform {
   required_version = ">= 1.10, < 2.0"
 
   required_providers {
+    # The AVM toolchain declares azapi in every terraform.tf it manages, and regenerates it on each
+    # pre-commit run, so the declaration cannot simply be removed. This submodule still holds its
+    # azurerm resource until the extension migration step lands, so azapi is declared here but not
+    # yet used. Drop this ignore once the submodule is on azapi.
+    # tflint-ignore: terraform_unused_required_providers
     azapi = {
       source  = "Azure/azapi"
       version = "~> 2.4"

--- a/modules/run-command/terraform.tf
+++ b/modules/run-command/terraform.tf
@@ -2,6 +2,11 @@ terraform {
   required_version = ">= 1.10, < 2.0"
 
   required_providers {
+    # The AVM toolchain declares azapi in every terraform.tf it manages, and regenerates it on each
+    # pre-commit run, so the declaration cannot simply be removed. This submodule still holds its
+    # azurerm resource until the run command migration step lands, so azapi is declared here but not
+    # yet used. Drop this ignore once the submodule is on azapi.
+    # tflint-ignore: terraform_unused_required_providers
     azapi = {
       source  = "Azure/azapi"
       version = "~> 2.4"


### PR DESCRIPTION
## Description

Lint currently fails on `main`. The AVM toolchain declares `Azure/azapi` in every `terraform.tf` it manages, including `modules/extension` and `modules/run-command`. Both submodules still hold their `azurerm` resources until the extension and run command migration steps land, so `azapi` is declared there but not used, and `terraform_unused_required_providers` fails on both:

```
modules/extension/terraform.tf:5     provider 'azapi' is declared in required_providers but not used by the module
modules/run-command/terraform.tf:5   provider 'azapi' is declared in required_providers but not used by the module
```

The failure threshold is `warning`, so these two take the run from `pass` to `fail`. They arrived with `0a415ab`, the bot's own pre-commit run.

### What was ruled out

**Removing the declaration.** It is regenerated. Deleting it from both files and running pre-commit put it back, with a clean tree afterwards, so there is nothing to commit.

**Bumping managed files.** Upgrading 1.0.28 to 1.0.29 does not change the injection; `azapi` is still declared in both submodules afterwards.

**The repository level override.** Adding the rule to `avm.tflint.override.hcl` is accepted and the engine even reports it:

```
TFLint override disables rule 'terraform_unused_required_providers'.
```

but both findings still appear and the run still fails, so the override only reaches the AVM ruleset rules and not the stock `terraform_*` ones. Worth knowing separately; it looks like an Avm.Authoring limitation.

### What this does

An inline ignore on each declaration, which does work and does survive the transform step. Each carries a note on why it is there and when it should go.

Verified: lint `pass`, 0 warnings, 0 errors. Pre-commit was run twice afterwards and both the ignore and its comment survive intact, with the only changed files being the two `terraform.tf`.

This should merge before #405, which is otherwise green but inherits this failure from `main`.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
